### PR TITLE
simple script to remove designer and al extensions

### DIFF
--- a/scripts/CleanupDesignerAndALProjects.ps1
+++ b/scripts/CleanupDesignerAndALProjects.ps1
@@ -1,0 +1,13 @@
+& ' C:\Program Files (x86)\Microsoft Dynamics NAV\100\RoleTailored Client\NavModelTools.ps1 ' | Out-Null
+
+$instance = 'Navision_main'
+
+$alProjectLike = 'ALProject*'
+$designerExtLike = 'Designer_*'
+
+Get-NAVAppInfo $instance | Where-Object { $_.Name -like $alProjectLike -or $_.Name -like $designerExtLike } | `
+    ForEach-Object { 
+        Write-Host ('Removing ' + $_.Name)
+        Uninstall-NAVApp -Name $_.Name -ServerInstance $instance
+        Unpublish-NAVApp -Name $_.Name -ServerInstance $instance 
+    }


### PR DESCRIPTION
I often like to remove my previous AL test projects and designer extensions to get back to the starting point. I could also create a new Azure vm instance or restore a bak but the attached script is a lot easier for me