### PR TITLE
Added Option Caption ML snippet.

### DIFF
--- a/snippets/al.json
+++ b/snippets/al.json
@@ -148,6 +148,13 @@
             "\t\t\t${2:languageShortcut} = '${3:languageText}';"
         ]
     },
+    "Snippet: Option Caption ML": {
+        "prefix": "toptioncaptionml",
+        "body": [
+            "OptionCaptionML = ENU = '${1:englishText}',",
+            "\t\t\t${2:languageShortcut} = '${3:languageText}';"
+        ]
+    },
     "Snippet: If Table Empty Else": {
         "prefix": "tisemptyelse",
         "body": [


### PR DESCRIPTION
I find that the caption ML for option is missing. One can of cause use the toptionml and then edit the property name, but I find it more clean having its own snippet.