### PR TITLE
Snippets for handling control add-ins

### DIFF
--- a/snippets/controladdin.json
+++ b/snippets/controladdin.json
@@ -23,9 +23,10 @@
             "\tRecreateScript = '${5:script1.js}';",
             "\tRefreshScript = '${5:script1.js}';",
             "\tevent ${8:MyEvent()};",
+            "\t",
             "\tprocedure ${9:MyProcedure()};",
             "}"
         ],
-        "description": "Snippet to create Control Add-In object"
+        "description": "Snippet: Control Add-In"
     }
 }

--- a/snippets/controladdin.json
+++ b/snippets/controladdin.json
@@ -1,0 +1,31 @@
+{
+    "Snippet: Control Add-In": {
+        "prefix": "tcontroladdin",
+        "body": [
+            "controladdin ${1:MyControlAddIn}",
+            "{",
+            "\tRequestedHeight = ${3:300};",
+            "\tMinimumHeight = ${3:300};",
+            "\tMaximumHeight = ${3:300};",
+            "\tRequestedWidth = ${3:700};",
+            "\tMinimumWidth = ${3:700};",
+            "\tMaximumWidth = ${3:700};",
+            "\tVerticalStretch = ${4:true};",
+            "\tVerticalShrink = ${4:true};",
+            "\tHorizontalStretch = ${4:true};",
+            "\tHorizontalShrink = ${4:true};",
+            "\tScripts = ",
+            "\t\t'${5:script1.js}',",
+            "\t\t'${6:script2.js}';",
+            "\tStyleSheets =",
+            "\t\t'${7:style1.css}';",
+            "\tStartupScript = '${5:script1.js}';",
+            "\tRecreateScript = '${5:script1.js}';",
+            "\tRefreshScript = '${5:script1.js}';",
+            "\tevent ${8:MyEvent()};",
+            "\tprocedure ${9:MyProcedure()};",
+            "}"
+        ],
+        "description": "Snippet to create Control Add-In object"
+    }
+}

--- a/snippets/page.json
+++ b/snippets/page.json
@@ -65,12 +65,12 @@
         "body": [
             "usercontrol(${1:ControlName};${2:AddInName})",
             "{",
-            "\ttrigger ${3:MyTrigger()}\r",
+            "\ttrigger ${3:MyTrigger()}",
             "\tbegin",
             "\tend;",
             "}"
         ],
-        "description": "Inserts User Control Code to Page"
+        "description": "Snippet: Page User Control"
     }
     "Page of type list": {
         "prefix": "tpage",

--- a/snippets/page.json
+++ b/snippets/page.json
@@ -60,6 +60,18 @@
             "}"
         ]
     },
+    "Snippet: User Control": {
+        "prefix": "tusercontrol",
+        "body": [
+            "usercontrol(${1:ControlName};${2:AddInName})",
+            "{",
+            "\ttrigger ${3:MyTrigger()}\r",
+            "\tbegin",
+            "\tend;",
+            "}"
+        ],
+        "description": "Inserts User Control Code to Page"
+    }
     "Page of type list": {
         "prefix": "tpage",
         "body": [


### PR DESCRIPTION
I started porting our control add-ins to AL and noticed that there is no snippets to help adding control add-ins, so I created 2 snippets taddin (which adds controladdin object) and tusercontrol (which adds add-in control to page).