### PR TITLE
Snippet for XML tenant WebService

### DIFF
--- a/snippets/tenantwebservice.xml.json
+++ b/snippets/tenantwebservice.xml.json
@@ -1,0 +1,19 @@
+{
+"Snippet: Tenant Web Service XML": {
+		"prefix": "twebservice",
+		"body": [
+			"<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+			"<ExportedData>",
+			"\t<TenantWebServiceCollection>",
+			"\t\t<TenantWebService>",
+			"\t\t\t<ObjectType>${1|CodeUnit,Page,Query|}</ObjectType>",
+			"\t\t\t<ServiceName>${2:ServiceName}</ServiceName>",
+			"\t\t\t<ObjectID>${3:ObjectID}</ObjectID>",
+			"\t\t\t<Published>${4|true,false|}</Published>",
+			"\t\t</TenantWebService>",
+			"\t</TenantWebServiceCollection>",
+			"</ExportedData>"
+		],
+		"description": "Tenant Web Service"
+	}
+}


### PR DESCRIPTION
The VS Code snippet for **XML-Files** add the **_TenantWebService_** Definition to an AL Project:

The content of the XML-File will be generated by typing `twebservice`:

![image](https://user-images.githubusercontent.com/15800069/34487080-028afbb6-efd3-11e7-9a9b-70ea60044d2c.png)

```XML
<?xml version="1.0" encoding="utf-8"?>
<ExportedData>
    <TenantWebServiceCollection>
        <TenantWebService>
            <ObjectType>Query</ObjectType>
            <ServiceName>MyQuery</ServiceName>
            <ObjectID>50100</ObjectID>
            <Published>true</Published>
        </TenantWebService>
    </TenantWebServiceCollection>
</ExportedData>```