### PR TITLE
Include quotes in placeholder on event subscriber snippet

### DIFF
--- a/snippets/al.json
+++ b/snippets/al.json
@@ -126,7 +126,7 @@
     "Snippet: Event Subscriber": {
         "prefix": "teventsub",
         "body": [
-            "[EventSubscriber(ObjectType::${1:ObjectType}, ${2:ObjectId}, '${3:OnSomeEvent}', '${4:ElementName}', ${5:SkipOnMissingLicense}, ${6:SkipOnMissingPermission})]",
+            "[EventSubscriber(ObjectType::${1:ObjectType}, ${2:ObjectId}, ${3:'OnSomeEvent'}, '${4:ElementName}', ${5:SkipOnMissingLicense}, ${6:SkipOnMissingPermission})]",
             "local procedure ${7:MyProcedure}()",
             "begin",
             "\t$0",


### PR DESCRIPTION
When tabbing through the Event Subscriber snippet `OnSomeEvent` was between quotes. 
Upon executing vscode suggestions (Default `Ctrl + Space`), it would not suggest anything.


I changed the placeholder to include quotes, the suggestions in vscode works.