### PR TITLE
tkey variant for PK

### DIFF
--- a/snippets/table.json
+++ b/snippets/table.json
@@ -97,5 +97,16 @@
             "}"
         ],
         "description": "Snippet: Table Key"
+    },
+    "Snippet: Table PK Key": {
+        "prefix": "tkey",
+        "body": [
+            "key(PK; ${2:MyField})",
+            "{",
+            "\tClustered = true;",
+            "}",
+            "$0"
+        ],
+        "description": "Snippet: Table Key"
     }
 }

--- a/snippets/table.json
+++ b/snippets/table.json
@@ -101,7 +101,7 @@
     "Snippet: Table PK Key": {
         "prefix": "tkey",
         "body": [
-            "key(PK; ${2:MyField})",
+            "key(PK; ${1:MyField})",
             "{",
             "\tClustered = true;",
             "}",


### PR DESCRIPTION
I added tkey variant (do not want to add new snippet name) for PK key which has fixed name PK and clustered=true; to make all PKs with same definition.