### PR TITLE
ApplicationArea added into the TPageField snippet because it is now mandatory

### DIFF
--- a/snippets/page.json
+++ b/snippets/page.json
@@ -46,7 +46,8 @@
         "body": [
             "field(${1:MyField}; ${2:FieldSource})",
             "{",
-            "\t${3:FieldPropertyName} = ${0:FieldPropertyValue};",
+            "\tApplicationArea = ${3|All,Basic,Suite,Advanced};",
+            "\t${4:FieldPropertyName} = ${0:FieldPropertyValue};",
             "}"
         ],
         "description": "Snippet: Page Field"


### PR DESCRIPTION
I have added the ApplicationArea into the Page Field snippet, because latest version of AL extension make it mandatory.