### PR TITLE
Use a more robust way of finding the culture in the Txt Translation

### DIFF
--- a/scripts/Txt2Xliff.ps1
+++ b/scripts/Txt2Xliff.ps1
@@ -138,10 +138,18 @@ function ParseTxtLine {
     $translationObject["KeyPart"] = $keyPart
     $translationObject["Key"] = GetLegacyTranslationKey $keyPart
 
-    if(-not ($keyPart -match 'A(\d+)')) {
+    [int]$LCID = 0
+    $components = $keyPart -split "-"
+    foreach($component in $components) {
+        if($component.StartsWith("A")) {
+            if([int32]::TryParse($component.SubString(1) , [ref]$LCID )) {
+                break;
+            }
+        }
+    }
+    if($LCID -eq 0) {
         return $null
     }
-    [int]$LCID = $Matches[1]
     $CultureInfo = GetCultureInfo $LCID
     if(!$CultureInfo) {
         return $null


### PR DESCRIPTION
**Problem:**
Menusuite objects created lines that contains Hex values, and the previous way to find the language was to use Regex meant that it would find false matches.

**Solution:**
Split the key into its individual parts and do a simpler and more robust check for the LCID.