### PR TITLE
Use AL code highlighting in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/al-developer-experience-bug.md
+++ b/.github/ISSUE_TEMPLATE/al-developer-experience-bug.md
@@ -20,7 +20,9 @@ A clear and concise description of what the bug is.
 Steps and to reproduce the behavior:
 1. Go to '...'
 
-``` AL Code to reproduce the issue ```
+```AL
+AL Code to reproduce the issue 
+```
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/al-static-code-analysis-rule.md
+++ b/.github/ISSUE_TEMPLATE/al-static-code-analysis-rule.md
@@ -25,12 +25,16 @@ Description of why this rule is important.
 **Bad code sample**
 Example of what bad code the rule should catch:
 
-``` Example of bad code ```
+```AL
+Example of bad code
+```
 
 **Good code sample**
 Example of what code should look like:
 
-``` Example of good code ```
+```AL
+Example of good code
+```
 
 **Good and bad practices for fixing the rule**
 Description of good and bad solution to fixing this warning (only add this section if you have additional information besides the good and bad code samples).


### PR DESCRIPTION
Since Github now supports the AL language, I think it is a good time to use it in the issue Templates.