### PR TITLE
URL Typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/al-developer-experience-bug.md
+++ b/.github/ISSUE_TEMPLATE/al-developer-experience-bug.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-Read the contributing https://github.com/microsoft/AL/blob/master/CONTRIBUTING.MD guide before proceeding
+Read the contributing https://github.com/microsoft/AL/blob/master/CONTRIBUTING.md guide before proceeding
 
 Please follow this template in order for our developers to investigate your issue efficiently.
 


### PR DESCRIPTION
If you open the URL https://github.com/microsoft/AL/blob/master/CONTRIBUTING.MD from the text, you will see an error message:
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/9556549/194760901-00d15b60-b418-4de8-a949-2d323acadec9.png">

The ".MD" must be written in lower case, then it works: https://github.com/microsoft/AL/blob/master/CONTRIBUTING.md