### PR TITLE
Add silent dry-run mode for AL issue triage

### DIFF
--- a/.github/agents/al-issue-triager.agent.md
+++ b/.github/agents/al-issue-triager.agent.md
@@ -9,4 +9,15 @@ Read `.github/agents/al-issue-triager/AGENTS.md` and
 `.github/agents/al-issue-triager/references/scope.md` before starting. Triage only the issue that
 started this session. Do not modify repository files, create commits or branches, or open a pull
 request. Use `download-al-symbols` whenever a reproduction project needs platform, application, or
-dependency symbols. Return only the final standardized issue comment; do not post it yourself.
+dependency symbols. Use:
+
+- `verify-prerelease-altool`
+- `create-al-project`
+- `download-al-symbols`
+- `compile-al-app`
+- `run-al-code-analysis`
+- `publish-al-app`
+- `run-al-tests`
+- `verify-al-e2e`
+
+Return only the final standardized issue comment; do not post it yourself.

--- a/.github/agents/al-issue-triager.agent.md
+++ b/.github/agents/al-issue-triager.agent.md
@@ -8,4 +8,5 @@ You are the public issue triage agent for microsoft/AL.
 Read `.github/agents/al-issue-triager/AGENTS.md` and
 `.github/agents/al-issue-triager/references/scope.md` before starting. Triage only the issue that
 started this session. Do not modify repository files, create commits or branches, or open a pull
-request. Return only the final standardized issue comment; do not post it yourself.
+request. Use `download-al-symbols` whenever a reproduction project needs platform, application, or
+dependency symbols. Return only the final standardized issue comment; do not post it yourself.

--- a/.github/agents/al-issue-triager/AGENTS.md
+++ b/.github/agents/al-issue-triager/AGENTS.md
@@ -38,8 +38,8 @@ The setup workflow provides:
 - `ALTOOL_VERSION`, `BC_ARTIFACT_URL`, `BC_CONTAINER_NAME`, `BC_SERVER_URL`,
   `BC_SERVER_INSTANCE`, `BC_AUTHENTICATION`, `BC_SERVER_USERNAME`, and the masked, ephemeral
   `BC_SERVER_PASSWORD`;
-- an AL language MCP server launched by ALTool, exposing `al_downloadsymbols` and the other AL
-  workspace tools.
+- a deterministic `download-al-symbols` skill that invokes the freshly installed prerelease ALTool
+  non-interactively.
 
 Start by verifying `al --version`, the environment variables, and container availability. If
 setup is incomplete, continue with safe read-only investigation and record the exact setup failure in
@@ -57,20 +57,20 @@ the reproduction row. Never reinterpret an environment failure as a product repr
 5. Inspect relevant public source, tests, documentation, and recent changes. Cite exact paths, issue
    numbers, commits, or public URLs.
 6. Attempt safe reproduction when the issue is in scope and provides sufficient inline material:
-   - use the installed ALTool command-line tool and the AL language MCP server it launches for
-     project/workspace creation, `al_downloadsymbols`, analyzer execution, compilation, publish, and
-     tests;
+   - use the freshly installed prerelease ALTool command-line tool for project/workspace creation,
+     symbol download, analyzer execution, compilation, publish, and tests;
    - when `app.json` references platform, application, or dependency packages, invoke
-     `al_downloadsymbols` before compiling and confirm that `.alpackages` contains the requested
-     packages;
+     `download-al-symbols` before compiling and confirm that `.alpackages` contains the requested
+     packages. The skill owns ALTool's internal symbol-download protocol; do not launch or script an
+     MCP server yourself;
    - never invoke `alc.exe` directly and never call `/dev/packages` manually; those paths bypass the
      configured ALTool workspace and non-interactive sandbox credentials;
    - use the running latest BCInsider Platform master sandbox for publish/runtime checks;
    - create temporary fixtures outside the repository checkout;
    - record exact commands and observed results;
    - remove temporary fixtures when done.
-7. If an ALTool operation fails, report the exact tool call and response. A direct compiler failure or
-   manual HTTP 401 is not evidence that ALTool cannot obtain symbols.
+7. If an ALTool operation fails, report the exact command or skill call and response. A direct
+   compiler failure or manual HTTP 401 is not evidence that ALTool cannot obtain symbols.
 8. If reproduction is unsafe or impossible, state the exact missing input or environment capability.
 9. Keep observed evidence separate from hypotheses. Never claim a root cause, regression, duplicate,
    or reproduction without evidence.

--- a/.github/agents/al-issue-triager/AGENTS.md
+++ b/.github/agents/al-issue-triager/AGENTS.md
@@ -36,7 +36,9 @@ The setup workflow provides:
 - a running Business Central sandbox container created from the latest BCInsider Platform master W1
   artifact, with no public `bcartifacts` fallback;
 - `ALTOOL_VERSION`, `BC_ARTIFACT_URL`, `BC_CONTAINER_NAME`, `BC_SERVER_URL`,
-  `BC_SERVER_INSTANCE`, `BC_AUTHENTICATION`, `BC_USERNAME`, and the masked, ephemeral `BC_PASSWORD`.
+  `BC_SERVER_INSTANCE`, `BC_AUTHENTICATION`, `BC_SERVER_USERNAME`, and the masked, ephemeral
+  `BC_SERVER_PASSWORD`;
+- an `altool` MCP server exposing `al_downloadsymbols` and the other AL workspace tools.
 
 Start by verifying `al --version`, the environment variables, and container availability. If
 setup is incomplete, continue with safe read-only investigation and record the exact setup failure in
@@ -54,13 +56,22 @@ the reproduction row. Never reinterpret an environment failure as a product repr
 5. Inspect relevant public source, tests, documentation, and recent changes. Cite exact paths, issue
    numbers, commits, or public URLs.
 6. Attempt safe reproduction when the issue is in scope and provides sufficient inline material:
-   - use the installed latest AL Development Tools for compiler/tooling checks;
+   - use the installed latest AL Development Tools through the `altool` MCP server for
+     project/workspace creation, `al_downloadsymbols`, analyzer execution, compilation, publish, and
+     tests;
+   - when `app.json` references platform, application, or dependency packages, invoke
+     `al_downloadsymbols` before compiling and confirm that `.alpackages` contains the requested
+     packages;
+   - never invoke `alc.exe` directly and never call `/dev/packages` manually; those paths bypass the
+     configured ALTool workspace and non-interactive sandbox credentials;
    - use the running latest BCInsider Platform master sandbox for publish/runtime checks;
    - create temporary fixtures outside the repository checkout;
    - record exact commands and observed results;
    - remove temporary fixtures when done.
-7. If reproduction is unsafe or impossible, state the exact missing input or environment capability.
-8. Keep observed evidence separate from hypotheses. Never claim a root cause, regression, duplicate,
+7. If an ALTool operation fails, report the exact tool call and response. A direct compiler failure or
+   manual HTTP 401 is not evidence that ALTool cannot obtain symbols.
+8. If reproduction is unsafe or impossible, state the exact missing input or environment capability.
+9. Keep observed evidence separate from hypotheses. Never claim a root cause, regression, duplicate,
    or reproduction without evidence.
 
 ## Comment contract
@@ -79,7 +90,6 @@ comment`; the workflow validates and posts the response. Use this exact section 
 
 - **AL Development Tools:** `<version or unavailable>`
 - **Business Central artifact:** `<artifact URL/version or unavailable>`
-- **Business Central container:** `<available | unavailable>` - <brief evidence>
 
 ### Attempts and results
 
@@ -89,7 +99,7 @@ comment`; the workflow validates and posts the response. Use this exact section 
 | Duplicate search | `<none found | possible duplicate(s)>` | <queries and up to three issue links, or "No strong match"> |
 | Repository investigation | `<confirmed | not confirmed | not applicable>` | <paths, docs, commits, or exact reason> |
 | ALTool reproduction | `<reproduced | not reproduced | inconclusive | not attempted>` | <exact command/result or blocker> |
-| BC container reproduction | `<reproduced | not reproduced | inconclusive | not attempted>` | <exact command/result or blocker> |
+| BC runtime reproduction | `<reproduced | not reproduced | inconclusive | not attempted>` | <exact command/result or blocker> |
 
 ### Assessment
 
@@ -102,6 +112,8 @@ comment`; the workflow validates and posts the response. Use this exact section 
 <one concrete next action for the reporter or maintainer>
 ```
 
-Every environment item and attempt row is mandatory, even when unavailable, not applicable, or not
-attempted. Keep the comment concise and public-safe. Do not include hidden reasoning, secrets, private
-system references, or a second comment.
+Every listed environment item and attempt row is mandatory, even when unavailable, not applicable, or
+not attempted. Do not disclose sandbox/container availability or setup mechanics in the public
+comment. Keep the comment concise and public-safe. Do not include progress narration, hidden
+reasoning, secrets, private system references, or a second comment. The first output characters must
+be the `## Automated AL issue triage` heading.

--- a/.github/agents/al-issue-triager/AGENTS.md
+++ b/.github/agents/al-issue-triager/AGENTS.md
@@ -38,7 +38,8 @@ The setup workflow provides:
 - `ALTOOL_VERSION`, `BC_ARTIFACT_URL`, `BC_CONTAINER_NAME`, `BC_SERVER_URL`,
   `BC_SERVER_INSTANCE`, `BC_AUTHENTICATION`, `BC_SERVER_USERNAME`, and the masked, ephemeral
   `BC_SERVER_PASSWORD`;
-- an `altool` MCP server exposing `al_downloadsymbols` and the other AL workspace tools.
+- an AL language MCP server launched by ALTool, exposing `al_downloadsymbols` and the other AL
+  workspace tools.
 
 Start by verifying `al --version`, the environment variables, and container availability. If
 setup is incomplete, continue with safe read-only investigation and record the exact setup failure in
@@ -56,7 +57,7 @@ the reproduction row. Never reinterpret an environment failure as a product repr
 5. Inspect relevant public source, tests, documentation, and recent changes. Cite exact paths, issue
    numbers, commits, or public URLs.
 6. Attempt safe reproduction when the issue is in scope and provides sufficient inline material:
-   - use the installed latest AL Development Tools through the `altool` MCP server for
+   - use the installed ALTool command-line tool and the AL language MCP server it launches for
      project/workspace creation, `al_downloadsymbols`, analyzer execution, compilation, publish, and
      tests;
    - when `app.json` references platform, application, or dependency packages, invoke

--- a/.github/agents/al-issue-triager/AGENTS.md
+++ b/.github/agents/al-issue-triager/AGENTS.md
@@ -57,8 +57,9 @@ the reproduction row. Never reinterpret an environment failure as a product repr
 5. Inspect relevant public source, tests, documentation, and recent changes. Cite exact paths, issue
    numbers, commits, or public URLs.
 6. Attempt safe reproduction when the issue is in scope and provides sufficient inline material:
-   - use the freshly installed prerelease ALTool command-line tool for project/workspace creation,
-     symbol download, analyzer execution, compilation, publish, and tests;
+   - invoke `verify-prerelease-altool`, then select the smallest applicable skill:
+     `create-al-project`, `download-al-symbols`, `compile-al-app`, `run-al-code-analysis`,
+     `publish-al-app`, `run-al-tests`, or `verify-al-e2e`;
    - when `app.json` references platform, application, or dependency packages, invoke
      `download-al-symbols` before compiling and confirm that `.alpackages` contains the requested
      packages. The skill owns ALTool's internal symbol-download protocol; do not launch or script an

--- a/.github/skills/compile-al-app/Invoke-CompileAlApp.ps1
+++ b/.github/skills/compile-al-app/Invoke-CompileAlApp.ps1
@@ -1,0 +1,96 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $ProjectPath,
+
+    [string] $PackageCachePath,
+
+    [string] $OutputPath,
+
+    [string[]] $CompilerArgument = @()
+)
+
+$ErrorActionPreference = 'Stop'
+$project = (Resolve-Path -LiteralPath $ProjectPath).Path
+$manifestPath = Join-Path $project 'app.json'
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    throw "AL project manifest not found: $manifestPath"
+}
+
+$manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+$hasSymbolReferences =
+    ($manifest.PSObject.Properties['platform'] -and $manifest.platform) -or
+    ($manifest.PSObject.Properties['application'] -and $manifest.application) -or
+    ($manifest.PSObject.Properties['dependencies'] -and @($manifest.dependencies).Count -gt 0)
+
+$altool = $env:ALTOOL_PATH
+if (-not (Test-Path -LiteralPath $altool -PathType Leaf)) {
+    throw "Prerelease ALTool not found: $altool"
+}
+$version = (& $altool --version 2>&1 | Out-String).Trim()
+if ($version -ne $env:ALTOOL_VERSION) {
+    throw "Expected ALTool '$env:ALTOOL_VERSION', got '$version'."
+}
+
+if (-not $PackageCachePath) {
+    $PackageCachePath = Join-Path $project '.alpackages'
+}
+$packageCache = [IO.Path]::GetFullPath($PackageCachePath)
+if ($hasSymbolReferences -and
+    @(Get-ChildItem -LiteralPath $packageCache -Filter '*.app' -File -ErrorAction SilentlyContinue).Count -eq 0) {
+    throw "Project '$project' requires symbols. Invoke download-al-symbols first."
+}
+
+if (-not $OutputPath) {
+    $safeName = ([string]$manifest.name -replace '[^A-Za-z0-9._-]', '-').Trim('-')
+    $temporaryRoot = if ($env:RUNNER_TEMP) {
+        $env:RUNNER_TEMP
+    } else {
+        [IO.Path]::GetTempPath()
+    }
+    $outputDirectory = Join-Path $temporaryRoot "al-triage-build\$([guid]::NewGuid().ToString('N'))"
+    $OutputPath = Join-Path $outputDirectory "$safeName.app"
+}
+$output = [IO.Path]::GetFullPath($OutputPath)
+New-Item -ItemType Directory -Path (Split-Path -Parent $output) -Force | Out-Null
+Remove-Item -LiteralPath $output -Force -ErrorAction SilentlyContinue
+
+$arguments = @('compile', "/project:$project", "/out:$output")
+if (Test-Path -LiteralPath $packageCache) {
+    $arguments += "/packagecachepath:$packageCache"
+}
+$arguments += $CompilerArgument
+
+$stdout = @(& $altool @arguments 2>&1)
+$exitCode = $LASTEXITCODE
+$outputText = ($stdout | Out-String).Trim()
+if ($exitCode -ne 0) {
+    [ordered]@{
+        succeeded = $false
+        nativeExitCode = $exitCode
+        projectPath = $project
+        appPath = $output
+        output = $outputText
+    } | ConvertTo-Json -Depth 5
+    exit $exitCode
+}
+if (-not (Test-Path -LiteralPath $output -PathType Leaf) -or (Get-Item $output).Length -le 0) {
+    throw "ALTool exited successfully without emitting a non-empty package at '$output'."
+}
+
+$packageManifest = (& $altool GetPackageManifest $output 2>&1 | Out-String).Trim()
+if ($LASTEXITCODE -ne 0 -or -not $packageManifest) {
+    throw "ALTool could not read the emitted package manifest: $packageManifest"
+}
+
+[ordered]@{
+    succeeded = $true
+    nativeExitCode = 0
+    altoolVersion = $version
+    projectPath = $project
+    packageCachePath = $packageCache
+    appPath = $output
+    appSize = (Get-Item $output).Length
+    package = ($packageManifest | ConvertFrom-Json)
+    output = $outputText
+} | ConvertTo-Json -Depth 6

--- a/.github/skills/compile-al-app/SKILL.md
+++ b/.github/skills/compile-al-app/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: compile-al-app
+description: Compiles a temporary AL project through the workflow-installed public prerelease ALTool and verifies that a fresh app package was emitted.
+argument-hint: "<project-folder> [package-cache-folder] [output-app]"
+---
+
+Invoke `verify-prerelease-altool`, then run:
+
+```powershell
+& .\.github\skills\compile-al-app\Invoke-CompileAlApp.ps1 `
+    -ProjectPath <project-folder> `
+    -PackageCachePath <project-folder>\.alpackages
+```
+
+If `app.json` references platform, application, or dependencies, invoke `download-al-symbols` first.
+Preserve compiler diagnostics and the native exit code. Do not invoke `alc.exe` directly.

--- a/.github/skills/create-al-project/SKILL.md
+++ b/.github/skills/create-al-project/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: create-al-project
+description: Creates the smallest temporary AL project needed to reproduce a public issue without VS Code.
+argument-hint: "<project-name>"
+---
+
+1. Invoke `verify-prerelease-altool`.
+2. Create the project under `$env:RUNNER_TEMP`, never inside the repository checkout.
+3. Write `app.json` with a new GUID, name, publisher, version, target, runtime, and the smallest ID
+   range needed by the report.
+4. Add `platform`, `application`, and dependencies only when the scenario needs them.
+5. Add only the AL source and analyzer settings required by the reported steps.
+6. If symbol references exist, invoke `download-al-symbols`.
+7. Compile with `compile-al-app`.
+
+Do not launch VS Code or invoke `AL: Go!`.

--- a/.github/skills/download-al-symbols/Invoke-DownloadAlSymbols.ps1
+++ b/.github/skills/download-al-symbols/Invoke-DownloadAlSymbols.ps1
@@ -1,0 +1,233 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $ProjectPath,
+
+    [string] $PackageCachePath,
+
+    [switch] $Force,
+
+    [int] $TimeoutSeconds = 300
+)
+
+$ErrorActionPreference = 'Stop'
+$project = (Resolve-Path -LiteralPath $ProjectPath).Path
+$manifestPath = Join-Path $project 'app.json'
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    throw "AL project manifest not found: $manifestPath"
+}
+
+$manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+$referenceCount = 0
+foreach ($property in @('platform', 'application')) {
+    if ($manifest.PSObject.Properties[$property] -and $manifest.$property) {
+        $referenceCount++
+    }
+}
+if ($manifest.PSObject.Properties['dependencies'] -and $manifest.dependencies) {
+    $referenceCount += @($manifest.dependencies).Count
+}
+if ($referenceCount -eq 0) {
+    throw "Project '$project' has no platform, application, or dependency symbols to download."
+}
+
+$altoolPath = $env:ALTOOL_PATH
+if ([string]::IsNullOrWhiteSpace($altoolPath)) {
+    $altoolPath = (Get-Command al -ErrorAction Stop).Source
+}
+if (-not (Test-Path -LiteralPath $altoolPath -PathType Leaf)) {
+    throw "Prerelease ALTool not found: $altoolPath"
+}
+
+$version = (& $altoolPath --version 2>&1 | Out-String).Trim()
+if (-not $version) {
+    throw 'Prerelease ALTool did not report a version.'
+}
+if ($env:ALTOOL_VERSION -and $version -ne $env:ALTOOL_VERSION) {
+    throw "ALTool version changed after setup. Expected '$env:ALTOOL_VERSION', got '$version'."
+}
+
+foreach ($name in @(
+    'BC_SERVER_URL',
+    'BC_SERVER_INSTANCE',
+    'BC_SERVER_PORT',
+    'BC_AUTHENTICATION',
+    'BC_SERVER_USERNAME',
+    'BC_SERVER_PASSWORD'
+)) {
+    if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+        throw "Required ALTool connection variable '$name' is unavailable."
+    }
+}
+
+if (-not $PackageCachePath) {
+    $PackageCachePath = Join-Path $project '.alpackages'
+}
+New-Item -ItemType Directory -Path $PackageCachePath -Force | Out-Null
+$packageCache = (Resolve-Path -LiteralPath $PackageCachePath).Path
+
+$startInfo = [Diagnostics.ProcessStartInfo]::new()
+$startInfo.FileName = $altoolPath
+$startInfo.UseShellExecute = $false
+$startInfo.RedirectStandardInput = $true
+$startInfo.RedirectStandardOutput = $true
+$startInfo.RedirectStandardError = $true
+$startInfo.CreateNoWindow = $true
+$startInfo.ArgumentList.Add('launchmcpserver')
+$startInfo.ArgumentList.Add($project)
+$startInfo.ArgumentList.Add('--transport')
+$startInfo.ArgumentList.Add('stdio')
+$startInfo.ArgumentList.Add('--packagecachepath')
+$startInfo.ArgumentList.Add($packageCache)
+
+$process = [Diagnostics.Process]::new()
+$process.StartInfo = $startInfo
+$requestId = 0
+
+function Send-Request {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Method,
+        [hashtable] $Parameters,
+        [int] $Timeout = 120
+    )
+
+    $script:requestId++
+    $id = $script:requestId
+    $message = @{
+        jsonrpc = '2.0'
+        id = $id
+        method = $Method
+    }
+    if ($null -ne $Parameters) {
+        $message.params = $Parameters
+    }
+    $process.StandardInput.WriteLine(($message | ConvertTo-Json -Depth 20 -Compress))
+    $process.StandardInput.Flush()
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($Timeout)
+    $pendingRead = $null
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if ($process.HasExited) {
+            throw "ALTool symbol-download process exited unexpectedly with code $($process.ExitCode)."
+        }
+        if ($null -eq $pendingRead) {
+            $pendingRead = $process.StandardOutput.ReadLineAsync()
+        }
+        if (-not $pendingRead.Wait(1000)) {
+            continue
+        }
+        $line = $pendingRead.Result
+        $pendingRead = $null
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+        try {
+            $response = $line | ConvertFrom-Json
+        }
+        catch {
+            continue
+        }
+        if ($response.PSObject.Properties['id'] -and $response.id -eq $id) {
+            return $response
+        }
+    }
+    throw "Timed out waiting for ALTool response to '$Method'."
+}
+
+try {
+    $process.Start() | Out-Null
+
+    $ready = $false
+    $deadline = [DateTime]::UtcNow.AddSeconds(30)
+    $pendingError = $null
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if ($process.HasExited) {
+            throw "ALTool exited during symbol-download startup with code $($process.ExitCode)."
+        }
+        if ($null -eq $pendingError) {
+            $pendingError = $process.StandardError.ReadLineAsync()
+        }
+        if (-not $pendingError.Wait(500)) {
+            continue
+        }
+        $line = $pendingError.Result
+        $pendingError = $null
+        if ($line -match 'Server Ready') {
+            $ready = $true
+            break
+        }
+    }
+    if (-not $ready) {
+        throw 'ALTool symbol-download service did not become ready within 30 seconds.'
+    }
+    $stderrDrain = $process.StandardError.ReadToEndAsync()
+
+    $initialize = Send-Request -Method 'initialize' -Parameters @{
+        protocolVersion = '2024-11-05'
+        capabilities = @{}
+        clientInfo = @{ name = 'public-al-triage'; version = '1.0.0' }
+    }
+    if ($initialize.PSObject.Properties['error']) {
+        throw "ALTool initialization failed: $($initialize.error | ConvertTo-Json -Compress)"
+    }
+    $process.StandardInput.WriteLine((@{
+        jsonrpc = '2.0'
+        method = 'notifications/initialized'
+    } | ConvertTo-Json -Compress))
+    $process.StandardInput.Flush()
+
+    $response = Send-Request -Method 'tools/call' -Timeout $TimeoutSeconds -Parameters @{
+        name = 'al_downloadsymbols'
+        arguments = @{
+            projectPath = $project
+            serverUrl = $env:BC_SERVER_URL
+            serverInstance = $env:BC_SERVER_INSTANCE
+            port = [int]$env:BC_SERVER_PORT
+            environmentType = 'OnPrem'
+            authentication = $env:BC_AUTHENTICATION
+            force = [bool]$Force
+            useInteractiveLogin = $false
+        }
+    }
+    if ($response.PSObject.Properties['error']) {
+        throw "ALTool symbol download failed: $($response.error | ConvertTo-Json -Depth 10 -Compress)"
+    }
+
+    $text = @($response.result.content |
+        Where-Object { $_.type -eq 'text' } |
+        Select-Object -First 1).text
+    if (-not $text) {
+        throw 'ALTool symbol download returned no result.'
+    }
+    $result = $text | ConvertFrom-Json
+    if (-not $result.succeeded) {
+        throw "ALTool symbol download was unsuccessful: $($result | ConvertTo-Json -Depth 10 -Compress)"
+    }
+
+    $packages = @(Get-ChildItem -LiteralPath $packageCache -Filter '*.app' -File)
+    if ($packages.Count -eq 0) {
+        throw "ALTool reported success but '$packageCache' contains no symbol packages."
+    }
+
+    [ordered]@{
+        succeeded = $true
+        altoolVersion = $version
+        projectPath = $project
+        packageCachePath = $packageCache
+        packageCount = $packages.Count
+        packages = @($packages.FullName)
+    } | ConvertTo-Json -Depth 5
+}
+finally {
+    try {
+        $process.StandardInput.Close()
+    }
+    catch {
+    }
+    if (-not $process.HasExited) {
+        $process.Kill()
+        $process.WaitForExit(3000) | Out-Null
+    }
+    $process.Dispose()
+}

--- a/.github/skills/download-al-symbols/Invoke-DownloadAlSymbols.ps1
+++ b/.github/skills/download-al-symbols/Invoke-DownloadAlSymbols.ps1
@@ -33,7 +33,7 @@ if ($referenceCount -eq 0) {
 
 $altoolPath = $env:ALTOOL_PATH
 if ([string]::IsNullOrWhiteSpace($altoolPath)) {
-    $altoolPath = (Get-Command al -ErrorAction Stop).Source
+    throw 'ALTOOL_PATH is unavailable. The workflow-installed prerelease ALTool is required.'
 }
 if (-not (Test-Path -LiteralPath $altoolPath -PathType Leaf)) {
     throw "Prerelease ALTool not found: $altoolPath"
@@ -83,6 +83,7 @@ $startInfo.ArgumentList.Add($packageCache)
 $process = [Diagnostics.Process]::new()
 $process.StartInfo = $startInfo
 $requestId = 0
+$processStarted = $false
 
 function Send-Request {
     param(
@@ -137,6 +138,7 @@ function Send-Request {
 
 try {
     $process.Start() | Out-Null
+    $processStarted = $true
 
     $ready = $false
     $deadline = [DateTime]::UtcNow.AddSeconds(30)
@@ -220,12 +222,8 @@ try {
     } | ConvertTo-Json -Depth 5
 }
 finally {
-    try {
+    if ($processStarted -and -not $process.HasExited) {
         $process.StandardInput.Close()
-    }
-    catch {
-    }
-    if (-not $process.HasExited) {
         $process.Kill()
         $process.WaitForExit(3000) | Out-Null
     }

--- a/.github/skills/download-al-symbols/Invoke-DownloadAlSymbols.ps1
+++ b/.github/skills/download-al-symbols/Invoke-DownloadAlSymbols.ps1
@@ -51,6 +51,7 @@ foreach ($name in @(
     'BC_SERVER_URL',
     'BC_SERVER_INSTANCE',
     'BC_SERVER_PORT',
+    'BC_TENANT',
     'BC_AUTHENTICATION',
     'BC_SERVER_USERNAME',
     'BC_SERVER_PASSWORD'
@@ -186,6 +187,7 @@ try {
             serverUrl = $env:BC_SERVER_URL
             serverInstance = $env:BC_SERVER_INSTANCE
             port = [int]$env:BC_SERVER_PORT
+            tenant = $env:BC_TENANT
             environmentType = 'OnPrem'
             authentication = $env:BC_AUTHENTICATION
             force = [bool]$Force

--- a/.github/skills/download-al-symbols/SKILL.md
+++ b/.github/skills/download-al-symbols/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: download-al-symbols
+description: Downloads exact Business Central symbol packages for a temporary AL reproduction project through the installed prerelease ALTool. Use before compiling any project whose app.json references platform, application, or dependency packages.
+argument-hint: "<project-folder>"
+---
+
+Run the deterministic wrapper:
+
+```powershell
+& .\.github\skills\download-al-symbols\Invoke-DownloadAlSymbols.ps1 `
+    -ProjectPath <project-folder>
+```
+
+The wrapper uses only the prerelease ALTool installed by the workflow at `ALTOOL_PATH`. It invokes
+ALTool's symbol-download capability non-interactively with the sandbox connection and credentials
+provided by the workflow, writes packages to `<project>\.alpackages`, and fails unless at least one
+package is present.
+
+Do not invoke `alc.exe`, launch or script an MCP server yourself, or call `/dev/packages` directly.
+After the wrapper succeeds, compile through ALTool and pass the populated `.alpackages` path.

--- a/.github/skills/download-al-symbols/SKILL.md
+++ b/.github/skills/download-al-symbols/SKILL.md
@@ -12,9 +12,9 @@ Run the deterministic wrapper:
 ```
 
 The wrapper uses only the prerelease ALTool installed by the workflow at `ALTOOL_PATH`. It invokes
-ALTool's symbol-download capability non-interactively with the sandbox connection and credentials
-provided by the workflow, writes packages to `<project>\.alpackages`, and fails unless at least one
-package is present.
+ALTool's symbol-download capability non-interactively with the sandbox connection, tenant, and
+credentials provided by the workflow, writes packages to `<project>\.alpackages`, and fails unless
+at least one package is present.
 
 Do not invoke `alc.exe`, launch or script an MCP server yourself, or call `/dev/packages` directly.
 After the wrapper succeeds, compile through ALTool and pass the populated `.alpackages` path.

--- a/.github/skills/publish-al-app/SKILL.md
+++ b/.github/skills/publish-al-app/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: publish-al-app
+description: Publishes one compiled AL app to the provisioned BCInsider sandbox through the public prerelease ALTool.
+argument-hint: "<app-path> [project-folder]"
+---
+
+1. Invoke `verify-prerelease-altool`.
+2. Compile project inputs with `compile-al-app`; use the emitted `.app` path.
+3. Publish non-interactively:
+   ```powershell
+   & $env:ALTOOL_PATH publishapp $appPath `
+       --project $projectPath `
+       --server $env:BC_SERVER_URL `
+       --serverinstance $env:BC_SERVER_INSTANCE `
+       --port $env:BC_SERVER_PORT `
+       --authentication $env:BC_AUTHENTICATION `
+       --environmenttype OnPrem `
+       --schemaupdatemode Synchronize
+   ```
+4. Use `--forceupgrade`, `ForceSync`, or `Recreate` only when required by the reported scenario.
+5. Preserve output and exit code. Do not call `/dev/apps` directly.

--- a/.github/skills/publish-al-app/SKILL.md
+++ b/.github/skills/publish-al-app/SKILL.md
@@ -13,6 +13,7 @@ argument-hint: "<app-path> [project-folder]"
        --server $env:BC_SERVER_URL `
        --serverinstance $env:BC_SERVER_INSTANCE `
        --port $env:BC_SERVER_PORT `
+       --tenant $env:BC_TENANT `
        --authentication $env:BC_AUTHENTICATION `
        --environmenttype OnPrem `
        --schemaupdatemode Synchronize

--- a/.github/skills/run-al-code-analysis/SKILL.md
+++ b/.github/skills/run-al-code-analysis/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: run-al-code-analysis
+description: Runs CodeCop, PerTenantExtensionCop, UICop, or AppSourceCop against a temporary project through the public prerelease ALTool.
+argument-hint: "<project-folder> <analyzer>"
+---
+
+1. Invoke `verify-prerelease-altool`.
+2. Invoke `download-al-symbols` when the project has symbol references.
+3. Create a temporary `.code-workspace` through:
+   ```powershell
+   & $env:ALTOOL_PATH workspace create $workspaceFile $projectPath
+   ```
+4. Run the requested analyzer with ALTool workspace compile:
+   ```powershell
+   & $env:ALTOOL_PATH workspace compile $workspaceFile `
+       --packagecachepath (Join-Path $projectPath '.alpackages') `
+       --analyzers PTECop `
+       --outfolder $outputFolder `
+       --errorlogdirectory $errorLogFolder
+   ```
+   Select only the reported analyzer from `AppSourceCop`, `CodeCop`, `PTECop`, or `UICop`. Use
+   `--ruleset` when the issue supplies one. Never invoke `alc.exe`.
+5. Preserve the exact diagnostics and exit code. A missing analyzer, ruleset, or symbol package is an
+   inconclusive setup failure, not evidence that no diagnostic exists.
+6. Exercise both the reported case and the nearest valid control case when feasible.

--- a/.github/skills/run-al-tests/SKILL.md
+++ b/.github/skills/run-al-tests/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: run-al-tests
+description: Runs a published AL test codeunit against the provisioned BCInsider sandbox through the public prerelease ALTool.
+argument-hint: "<codeunit-id> [project-folder] [test-methods]"
+---
+
+1. Invoke `verify-prerelease-altool`.
+2. Publish the test app with `publish-al-app`.
+3. Run structured tests:
+   ```powershell
+   & $env:ALTOOL_PATH runtests $codeunitId `
+       --project $projectPath `
+       --server $env:BC_SERVER_URL `
+       --serverinstance $env:BC_SERVER_INSTANCE `
+       --port $env:BC_SERVER_PORT `
+       --authentication $env:BC_AUTHENTICATION `
+       --environmenttype OnPrem
+   ```
+4. Add `--testmethods` only when specific procedures are requested.
+5. Preserve the JSON response and native exit code; report passed, failed, and skipped counts.

--- a/.github/skills/run-al-tests/SKILL.md
+++ b/.github/skills/run-al-tests/SKILL.md
@@ -13,6 +13,7 @@ argument-hint: "<codeunit-id> [project-folder] [test-methods]"
        --server $env:BC_SERVER_URL `
        --serverinstance $env:BC_SERVER_INSTANCE `
        --port $env:BC_SERVER_PORT `
+       --tenant $env:BC_TENANT `
        --authentication $env:BC_AUTHENTICATION `
        --environmenttype OnPrem
    ```

--- a/.github/skills/verify-al-e2e/SKILL.md
+++ b/.github/skills/verify-al-e2e/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: verify-al-e2e
+description: Orchestrates the smallest production-path AL reproduction through the workflow-installed public prerelease ALTool and BCInsider sandbox.
+argument-hint: "<scenario>"
+---
+
+1. Invoke `verify-prerelease-altool`.
+2. Create the smallest fixture with `create-al-project`.
+3. Select the required path:
+   - compiler or diagnostic: `compile-al-app`;
+   - analyzer: `run-al-code-analysis`;
+   - platform/application dependencies: `download-al-symbols`, then `compile-al-app`;
+   - publish/install: `publish-al-app`;
+   - runtime behavior: `publish-al-app`, then `run-al-tests`.
+4. Run the reported case and a valid control case when feasible.
+5. Preserve ALTool version, BC artifact version, commands/skill calls, diagnostics, exit codes, and
+   test results.
+6. Keep all fixtures and output under `$env:RUNNER_TEMP` and remove them after evidence is captured.
+
+Do not replace execution with source reading when the scenario can run.

--- a/.github/skills/verify-prerelease-altool/SKILL.md
+++ b/.github/skills/verify-prerelease-altool/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: verify-prerelease-altool
+description: Verifies that the workflow-installed public prerelease ALTool is the executable used for every reproduction command.
+---
+
+Resolve ALTool only from `ALTOOL_PATH`, then verify it matches `ALTOOL_VERSION`:
+
+```powershell
+$altool = $env:ALTOOL_PATH
+if (-not (Test-Path -LiteralPath $altool -PathType Leaf)) {
+    throw "Prerelease ALTool not found: $altool"
+}
+$actualVersion = (& $altool --version 2>&1 | Out-String).Trim()
+if ($actualVersion -ne $env:ALTOOL_VERSION) {
+    throw "Expected ALTool '$env:ALTOOL_VERSION', got '$actualVersion'."
+}
+```
+
+Do not use a repository-built, globally cached, or separately downloaded executable.

--- a/.github/workflows/al-issue-triage.yml
+++ b/.github/workflows/al-issue-triage.yml
@@ -61,7 +61,9 @@ jobs:
           if (-not $alVersion) {
             throw 'The AL Development Tools installation did not report a version.'
           }
+          $altoolPath = (Get-Command al -ErrorAction Stop).Source
           "ALTOOL_VERSION=$alVersion" | Add-Content -Path $env:GITHUB_ENV
+          "ALTOOL_PATH=$altoolPath" | Add-Content -Path $env:GITHUB_ENV
 
       - name: Start latest BCInsider Platform master sandbox
         shell: pwsh
@@ -103,6 +105,7 @@ jobs:
           "BC_ARTIFACT_URL=$artifactUrl" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_URL=http://$containerName" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_INSTANCE=BC" | Add-Content -Path $env:GITHUB_ENV
+          "BC_SERVER_PORT=7049" | Add-Content -Path $env:GITHUB_ENV
           "BC_AUTHENTICATION=UserPassword" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV
@@ -129,24 +132,13 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
           $errorPath = Join-Path $env:RUNNER_TEMP 'al-triage-error.log'
-          $mcpConfigPath = Join-Path $env:RUNNER_TEMP 'al-triage-mcp.json'
-          @{
-            mcpServers = @{
-              'al-language' = @{
-                type = 'local'
-                command = 'al'
-                args = @('launchmcpserver', '--transport', 'stdio')
-                tools = @('*')
-              }
-            }
-          } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $mcpConfigPath -Encoding utf8
           $prompt = @"
           Triage public microsoft/AL issue #$env:TRIAGE_ISSUE_NUMBER.
           Read the complete issue payload from '$env:TRIAGE_ISSUE_PATH'.
           Follow the al-issue-triager custom agent and its AGENTS.md contract.
-          Investigate and reproduce safely using ALTool and the AL language MCP tools exposed by
-          `al launchmcpserver`, plus the running BCInsider sandbox. Use al_downloadsymbols before
-          compiling projects with symbol references. Do not invoke alc.exe directly or call
+          Investigate and reproduce safely using the freshly installed prerelease ALTool and running
+          BCInsider sandbox. Invoke the download-al-symbols skill before compiling projects with
+          symbol references. Do not launch or script an MCP server, invoke alc.exe directly, or call
           /dev/packages manually. Do not modify tracked repository files, create a branch, commit,
           pull request, label, assignment, or GitHub comment. Return only the final standardized
           markdown issue comment; the workflow will validate it.
@@ -160,7 +152,6 @@ jobs:
             --no-remote `
             --no-remote-export `
             --disable-builtin-mcps `
-            --additional-mcp-config "@$mcpConfigPath" `
             --allow-all-tools `
             --allow-all-paths `
             --allow-all-urls `

--- a/.github/workflows/al-issue-triage.yml
+++ b/.github/workflows/al-issue-triage.yml
@@ -9,6 +9,11 @@ on:
         description: Issue number to triage
         required: true
         type: number
+      dry_run:
+        description: Validate and archive triage without posting an issue comment
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -21,6 +26,7 @@ concurrency:
 
 env:
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: "api.github.com,github.com,nuget.org,registry.npmjs.org,powershellgallery.com,bcinsider.blob.core.windows.net,azureedge.net,azurefd.net,mcr.microsoft.com,data.mcr.microsoft.com,cdn.mscr.io"
+  TRIAGE_DRY_RUN: ${{ github.event_name == 'issues' || inputs.dry_run }}
 
 jobs:
   triage:
@@ -98,8 +104,8 @@ jobs:
           "BC_SERVER_URL=http://$containerName" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_INSTANCE=BC" | Add-Content -Path $env:GITHUB_ENV
           "BC_AUTHENTICATION=UserPassword" | Add-Content -Path $env:GITHUB_ENV
-          "BC_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
-          "BC_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV
+          "BC_SERVER_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
+          "BC_SERVER_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV
 
       - name: Capture triggering issue
         shell: pwsh
@@ -123,14 +129,26 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
           $errorPath = Join-Path $env:RUNNER_TEMP 'al-triage-error.log'
+          $mcpConfigPath = Join-Path $env:RUNNER_TEMP 'al-triage-mcp.json'
+          @{
+            mcpServers = @{
+              altool = @{
+                type = 'local'
+                command = 'al'
+                args = @('launchmcpserver', '--transport', 'stdio')
+                tools = @('*')
+              }
+            }
+          } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $mcpConfigPath -Encoding utf8
           $prompt = @"
           Triage public microsoft/AL issue #$env:TRIAGE_ISSUE_NUMBER.
           Read the complete issue payload from '$env:TRIAGE_ISSUE_PATH'.
           Follow the al-issue-triager custom agent and its AGENTS.md contract.
-          Investigate and reproduce safely using the installed AL Development Tools and running
-          BCInsider container. Do not modify tracked repository files, create a branch, commit,
-          pull request, label, assignment, or GitHub comment. Return only the final standardized
-          markdown issue comment; the workflow will validate and post it.
+          Investigate and reproduce safely using the altool MCP tools and running BCInsider container.
+          Use al_downloadsymbols before compiling projects with symbol references. Do not invoke
+          alc.exe directly or call /dev/packages manually. Do not modify tracked repository files,
+          create a branch, commit, pull request, label, assignment, or GitHub comment. Return only
+          the final standardized markdown issue comment; the workflow will validate it.
           "@
 
           & copilot `
@@ -141,6 +159,7 @@ jobs:
             --no-remote `
             --no-remote-export `
             --disable-builtin-mcps `
+            --additional-mcp-config "@$mcpConfigPath" `
             --allow-all-tools `
             --allow-all-paths `
             --allow-all-urls `
@@ -153,10 +172,17 @@ jobs:
             throw "Copilot CLI triage failed with exit code $LASTEXITCODE.`n$errorOutput"
           }
 
-      - name: Validate and post the single triage comment
+          $rawOutput = Get-Content -LiteralPath $commentPath -Raw
+          $heading = '## Automated AL issue triage'
+          $headingIndex = $rawOutput.IndexOf($heading, [StringComparison]::Ordinal)
+          if ($headingIndex -lt 0) {
+            throw "Copilot CLI triage output did not contain the required heading.`n$rawOutput"
+          }
+          $normalizedComment = $rawOutput.Substring($headingIndex).Trim()
+          Set-Content -LiteralPath $commentPath -Value $normalizedComment -Encoding utf8
+
+      - name: Validate triage output
         shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           $ErrorActionPreference = 'Stop'
           $commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
@@ -169,13 +195,12 @@ jobs:
             '### Environment',
             '**AL Development Tools:**',
             '**Business Central artifact:**',
-            '**Business Central container:**',
             '### Attempts and results',
             '| Report completeness |',
             '| Duplicate search |',
             '| Repository investigation |',
             '| ALTool reproduction |',
-            '| BC container reproduction |',
+            '| BC runtime reproduction |',
             '### Assessment',
             '### Recommended next step'
           )
@@ -183,17 +208,44 @@ jobs:
             if (-not $comment.Contains($text)) {
               throw "Triage output is missing required text '$text'."
             }
+            if (-not $comment.StartsWith('## Automated AL issue triage', [StringComparison]::Ordinal)) {
+              throw 'Triage output contains text before the required heading.'
+            }
           }
           if ($comment.Length -gt 12000) {
             throw "Triage output is too long ($($comment.Length) characters)."
           }
-          if ($env:BC_PASSWORD -and $comment.Contains($env:BC_PASSWORD)) {
+          if ($env:BC_SERVER_PASSWORD -and $comment.Contains($env:BC_SERVER_PASSWORD)) {
             throw 'Triage output contains the ephemeral sandbox password.'
           }
           if (git status --porcelain) {
             throw 'The triage agent modified tracked or untracked repository files.'
           }
 
+          "## Triage result for issue #$env:TRIAGE_ISSUE_NUMBER" |
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY
+          if ($env:TRIAGE_DRY_RUN -eq 'true') {
+            "> Dry run: validated and archived without posting to GitHub." |
+              Add-Content -Path $env:GITHUB_STEP_SUMMARY
+          }
+          $comment | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+
+      - name: Upload triage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: al-triage-issue-${{ github.event.issue.number || inputs.issue_number }}
+          path: ${{ runner.temp }}/al-triage-comment.md
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Post the single triage comment
+        if: env.TRIAGE_DRY_RUN != 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
           $existingComment = gh api `
             "repos/$env:GITHUB_REPOSITORY/issues/$env:TRIAGE_ISSUE_NUMBER/comments" `
             --paginate `

--- a/.github/workflows/al-issue-triage.yml
+++ b/.github/workflows/al-issue-triage.yml
@@ -137,11 +137,13 @@ jobs:
           Read the complete issue payload from '$env:TRIAGE_ISSUE_PATH'.
           Follow the al-issue-triager custom agent and its AGENTS.md contract.
           Investigate and reproduce safely using the freshly installed prerelease ALTool and running
-          BCInsider sandbox. Invoke the download-al-symbols skill before compiling projects with
-          symbol references. Do not launch or script an MCP server, invoke alc.exe directly, or call
-          /dev/packages manually. Do not modify tracked repository files, create a branch, commit,
-          pull request, label, assignment, or GitHub comment. Return only the final standardized
-          markdown issue comment; the workflow will validate it.
+          BCInsider sandbox. Invoke verify-prerelease-altool first, then use the smallest applicable
+          skill chain from create-al-project, download-al-symbols, compile-al-app,
+          run-al-code-analysis, publish-al-app, run-al-tests, and verify-al-e2e. Do not launch or
+          script an MCP server, invoke alc.exe directly, or call BC HTTP endpoints manually. Do not
+          modify tracked repository files, create a branch, commit, pull request, label, assignment,
+          or GitHub comment. Return only the final standardized markdown issue comment; the workflow
+          will validate it.
           "@
 
           & copilot `

--- a/.github/workflows/al-issue-triage.yml
+++ b/.github/workflows/al-issue-triage.yml
@@ -51,215 +51,35 @@ jobs:
 
       - name: Install triage tools
         shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          dotnet tool install --global Microsoft.Dynamics.BusinessCentral.Development.Tools --prerelease
-          npm install --global @github/copilot@1.0.79-9
-          Install-Module BcContainerHelper -Force -Scope CurrentUser -Repository PSGallery
-
-          $alVersion = (& al --version 2>&1 | Out-String).Trim()
-          if (-not $alVersion) {
-            throw 'The AL Development Tools installation did not report a version.'
-          }
-          $altoolPath = (Get-Command al -ErrorAction Stop).Source
-          "ALTOOL_VERSION=$alVersion" | Add-Content -Path $env:GITHUB_ENV
-          "ALTOOL_PATH=$altoolPath" | Add-Content -Path $env:GITHUB_ENV
+        run: .\scripts\al-issue-triage\Install-TriageTools.ps1
 
       - name: Start latest BCInsider Platform master sandbox
         shell: pwsh
         timeout-minutes: 35
-        run: |
-          $ErrorActionPreference = 'Stop'
-          Import-Module BcContainerHelper -Force
-
-          $artifactUrl = Get-BcArtifactUrl -Type Sandbox -Country w1 -Select Latest `
-            -StorageAccount bcinsider -Accept_InsiderEula
-          if (-not $artifactUrl -or [string]$artifactUrl -notmatch '(?i)bcinsider') {
-            throw "Could not resolve a BCInsider Platform master sandbox artifact: '$artifactUrl'."
-          }
-
-          $containerName = 'al-public-triage'
-          $passwordText = [guid]::NewGuid().ToString('N') + 'aA1!'
-          Write-Host "::add-mask::$passwordText"
-          $credential = [pscredential]::new(
-            'admin',
-            (ConvertTo-SecureString $passwordText -AsPlainText -Force)
-          )
-
-          New-BcContainer `
-            -Accept_Eula `
-            -Accept_InsiderEula `
-            -ContainerName $containerName `
-            -ArtifactUrl $artifactUrl `
-            -Auth UserPassword `
-            -Credential $credential `
-            -UpdateHosts `
-            -Shortcuts None `
-            -IncludeAL
-
-          if (-not (Get-BcContainerId -ContainerName $containerName)) {
-            throw "Business Central container '$containerName' was not created."
-          }
-
-          "BC_CONTAINER_NAME=$containerName" | Add-Content -Path $env:GITHUB_ENV
-          "BC_ARTIFACT_URL=$artifactUrl" | Add-Content -Path $env:GITHUB_ENV
-          "BC_SERVER_URL=http://$containerName" | Add-Content -Path $env:GITHUB_ENV
-          "BC_SERVER_INSTANCE=BC" | Add-Content -Path $env:GITHUB_ENV
-          "BC_SERVER_PORT=7049" | Add-Content -Path $env:GITHUB_ENV
-          "BC_TENANT=default" | Add-Content -Path $env:GITHUB_ENV
-          "BC_AUTHENTICATION=UserPassword" | Add-Content -Path $env:GITHUB_ENV
-          "BC_SERVER_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
-          "BC_SERVER_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV
+        run: .\scripts\al-issue-triage\Start-TriageSandbox.ps1
 
       - name: Verify prerelease ALTool sandbox access
         shell: pwsh
         timeout-minutes: 5
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $projectPath = Join-Path $env:RUNNER_TEMP 'altool-sandbox-preflight'
-          New-Item -ItemType Directory -Path $projectPath -Force | Out-Null
-          $artifactVersion = [regex]::Match(
-            $env:BC_ARTIFACT_URL,
-            '/(?<version>\d+\.\d+\.\d+\.\d+)/'
-          ).Groups['version'].Value
-          if (-not $artifactVersion) {
-            throw "Could not determine the BC artifact version from '$env:BC_ARTIFACT_URL'."
-          }
-          $versionParts = $artifactVersion.Split('.')
-          $applicationVersion = "$($versionParts[0]).$($versionParts[1]).0.0"
-          [ordered]@{
-            id = [guid]::NewGuid().ToString()
-            name = 'Public AL Triage Preflight'
-            publisher = 'Microsoft'
-            version = '1.0.0.0'
-            platform = $applicationVersion
-            application = $applicationVersion
-            target = 'OnPrem'
-            idRanges = @([ordered]@{ from = 50100; to = 50100 })
-          } | ConvertTo-Json -Depth 5 |
-            Set-Content -LiteralPath (Join-Path $projectPath 'app.json') -Encoding utf8
-
-          try {
-            & .\.github\skills\download-al-symbols\Invoke-DownloadAlSymbols.ps1 `
-              -ProjectPath $projectPath
-          }
-          finally {
-            Remove-Item -LiteralPath $projectPath -Recurse -Force -ErrorAction SilentlyContinue
-          }
+        run: .\scripts\al-issue-triage\Test-AlToolSandboxAccess.ps1
 
       - name: Capture triggering issue
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $issuePath = Join-Path $env:RUNNER_TEMP 'al-triage-issue.json'
-          gh api "repos/$env:GITHUB_REPOSITORY/issues/$env:ISSUE_NUMBER" |
-            Set-Content -LiteralPath $issuePath -Encoding utf8
-          "TRIAGE_ISSUE_NUMBER=$env:ISSUE_NUMBER" | Add-Content -Path $env:GITHUB_ENV
-          "TRIAGE_ISSUE_PATH=$issuePath" | Add-Content -Path $env:GITHUB_ENV
+        run: .\scripts\al-issue-triage\Get-TriggeringIssue.ps1
 
       - name: Run read-only AL issue triage
         shell: pwsh
         timeout-minutes: 20
         env:
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
-          $errorPath = Join-Path $env:RUNNER_TEMP 'al-triage-error.log'
-          $prompt = @"
-          Triage public microsoft/AL issue #$env:TRIAGE_ISSUE_NUMBER.
-          Read the complete issue payload from '$env:TRIAGE_ISSUE_PATH'.
-          Follow the al-issue-triager custom agent and its AGENTS.md contract.
-          Investigate and reproduce safely using the freshly installed prerelease ALTool and running
-          BCInsider sandbox. Invoke verify-prerelease-altool first, then use the smallest applicable
-          skill chain from create-al-project, download-al-symbols, compile-al-app,
-          run-al-code-analysis, publish-al-app, run-al-tests, and verify-al-e2e. Do not launch or
-          script an MCP server, invoke alc.exe directly, or call BC HTTP endpoints manually. Do not
-          modify tracked repository files, create a branch, commit, pull request, label, assignment,
-          or GitHub comment. Return only the final standardized markdown issue comment; the workflow
-          will validate it.
-          "@
-
-          & copilot `
-            --agent al-issue-triager `
-            --prompt $prompt `
-            --silent `
-            --no-ask-user `
-            --no-remote `
-            --no-remote-export `
-            --disable-builtin-mcps `
-            --allow-all-tools `
-            --allow-all-paths `
-            --allow-all-urls `
-            --secret-env-vars COPILOT_GITHUB_TOKEN `
-            1> $commentPath 2> $errorPath
-          if ($LASTEXITCODE -ne 0) {
-            $errorOutput = if (Test-Path -LiteralPath $errorPath) {
-              Get-Content -LiteralPath $errorPath -Raw
-            }
-            throw "Copilot CLI triage failed with exit code $LASTEXITCODE.`n$errorOutput"
-          }
-
-          $rawOutput = Get-Content -LiteralPath $commentPath -Raw
-          $heading = '## Automated AL issue triage'
-          $headingIndex = $rawOutput.IndexOf($heading, [StringComparison]::Ordinal)
-          if ($headingIndex -lt 0) {
-            throw "Copilot CLI triage output did not contain the required heading.`n$rawOutput"
-          }
-          $normalizedComment = $rawOutput.Substring($headingIndex).Trim()
-          Set-Content -LiteralPath $commentPath -Value $normalizedComment -Encoding utf8
+        run: .\scripts\al-issue-triage\Invoke-AlIssueTriage.ps1
 
       - name: Validate triage output
         shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
-          $comment = Get-Content -LiteralPath $commentPath -Raw
-
-          $requiredText = @(
-            '## Automated AL issue triage',
-            '**Classification:**',
-            '**Summary:**',
-            '### Environment',
-            '**AL Development Tools:**',
-            '**Business Central artifact:**',
-            '### Attempts and results',
-            '| Report completeness |',
-            '| Duplicate search |',
-            '| Repository investigation |',
-            '| ALTool reproduction |',
-            '| BC runtime reproduction |',
-            '### Assessment',
-            '### Recommended next step'
-          )
-          foreach ($text in $requiredText) {
-            if (-not $comment.Contains($text)) {
-              throw "Triage output is missing required text '$text'."
-            }
-            if (-not $comment.StartsWith('## Automated AL issue triage', [StringComparison]::Ordinal)) {
-              throw 'Triage output contains text before the required heading.'
-            }
-          }
-          if ($comment.Length -gt 12000) {
-            throw "Triage output is too long ($($comment.Length) characters)."
-          }
-          if ($env:BC_SERVER_PASSWORD -and $comment.Contains($env:BC_SERVER_PASSWORD)) {
-            throw 'Triage output contains the ephemeral sandbox password.'
-          }
-          if (git status --porcelain) {
-            throw 'The triage agent modified tracked or untracked repository files.'
-          }
-
-          "## Triage result for issue #$env:TRIAGE_ISSUE_NUMBER" |
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY
-          if ($env:TRIAGE_DRY_RUN -eq 'true') {
-            "> Dry run: validated and archived without posting to GitHub." |
-              Add-Content -Path $env:GITHUB_STEP_SUMMARY
-          }
-          $comment | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+        run: .\scripts\al-issue-triage\Test-AlIssueTriageOutput.ps1
 
       - name: Upload triage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -274,31 +94,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
-          $existingComment = gh api `
-            "repos/$env:GITHUB_REPOSITORY/issues/$env:TRIAGE_ISSUE_NUMBER/comments" `
-            --paginate `
-            --jq '.[] | select(.body | startswith("## Automated AL issue triage")) | .id' |
-            Select-Object -First 1
-          if ($existingComment) {
-            Write-Host "Issue #$env:TRIAGE_ISSUE_NUMBER already has an automated triage comment."
-            exit 0
-          }
-
-          gh issue comment $env:TRIAGE_ISSUE_NUMBER `
-            --repo $env:GITHUB_REPOSITORY `
-            --body-file $commentPath
+        run: .\scripts\al-issue-triage\Publish-AlIssueTriageComment.ps1
 
       - name: Stop disposable sandbox
         if: always()
         shell: pwsh
-        run: |
-          if (Get-Module BcContainerHelper -ListAvailable) {
-            Import-Module BcContainerHelper -Force
-            if ($env:BC_CONTAINER_NAME -and
-                (Get-BcContainerId -ContainerName $env:BC_CONTAINER_NAME)) {
-              Remove-BcContainer -ContainerName $env:BC_CONTAINER_NAME
-            }
-          }
+        run: .\scripts\al-issue-triage\Stop-TriageSandbox.ps1

--- a/.github/workflows/al-issue-triage.yml
+++ b/.github/workflows/al-issue-triage.yml
@@ -132,7 +132,7 @@ jobs:
           $mcpConfigPath = Join-Path $env:RUNNER_TEMP 'al-triage-mcp.json'
           @{
             mcpServers = @{
-              altool = @{
+              'al-language' = @{
                 type = 'local'
                 command = 'al'
                 args = @('launchmcpserver', '--transport', 'stdio')
@@ -144,11 +144,12 @@ jobs:
           Triage public microsoft/AL issue #$env:TRIAGE_ISSUE_NUMBER.
           Read the complete issue payload from '$env:TRIAGE_ISSUE_PATH'.
           Follow the al-issue-triager custom agent and its AGENTS.md contract.
-          Investigate and reproduce safely using the altool MCP tools and running BCInsider container.
-          Use al_downloadsymbols before compiling projects with symbol references. Do not invoke
-          alc.exe directly or call /dev/packages manually. Do not modify tracked repository files,
-          create a branch, commit, pull request, label, assignment, or GitHub comment. Return only
-          the final standardized markdown issue comment; the workflow will validate it.
+          Investigate and reproduce safely using ALTool and the AL language MCP tools exposed by
+          `al launchmcpserver`, plus the running BCInsider sandbox. Use al_downloadsymbols before
+          compiling projects with symbol references. Do not invoke alc.exe directly or call
+          /dev/packages manually. Do not modify tracked repository files, create a branch, commit,
+          pull request, label, assignment, or GitHub comment. Return only the final standardized
+          markdown issue comment; the workflow will validate it.
           "@
 
           & copilot `

--- a/.github/workflows/al-issue-triage.yml
+++ b/.github/workflows/al-issue-triage.yml
@@ -106,9 +106,46 @@ jobs:
           "BC_SERVER_URL=http://$containerName" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_INSTANCE=BC" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_PORT=7049" | Add-Content -Path $env:GITHUB_ENV
+          "BC_TENANT=default" | Add-Content -Path $env:GITHUB_ENV
           "BC_AUTHENTICATION=UserPassword" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV
+
+      - name: Verify prerelease ALTool sandbox access
+        shell: pwsh
+        timeout-minutes: 5
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $projectPath = Join-Path $env:RUNNER_TEMP 'altool-sandbox-preflight'
+          New-Item -ItemType Directory -Path $projectPath -Force | Out-Null
+          $artifactVersion = [regex]::Match(
+            $env:BC_ARTIFACT_URL,
+            '/(?<version>\d+\.\d+\.\d+\.\d+)/'
+          ).Groups['version'].Value
+          if (-not $artifactVersion) {
+            throw "Could not determine the BC artifact version from '$env:BC_ARTIFACT_URL'."
+          }
+          $versionParts = $artifactVersion.Split('.')
+          $applicationVersion = "$($versionParts[0]).$($versionParts[1]).0.0"
+          [ordered]@{
+            id = [guid]::NewGuid().ToString()
+            name = 'Public AL Triage Preflight'
+            publisher = 'Microsoft'
+            version = '1.0.0.0'
+            platform = $applicationVersion
+            application = $applicationVersion
+            target = 'OnPrem'
+            idRanges = @([ordered]@{ from = 50100; to = 50100 })
+          } | ConvertTo-Json -Depth 5 |
+            Set-Content -LiteralPath (Join-Path $projectPath 'app.json') -Encoding utf8
+
+          try {
+            & .\.github\skills\download-al-symbols\Invoke-DownloadAlSymbols.ps1 `
+              -ProjectPath $projectPath
+          }
+          finally {
+            Remove-Item -LiteralPath $projectPath -Recurse -Force -ErrorAction SilentlyContinue
+          }
 
       - name: Capture triggering issue
         shell: pwsh

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -89,6 +89,7 @@ jobs:
           "BC_SERVER_URL=http://$containerName" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_INSTANCE=BC" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_PORT=7049" | Add-Content -Path $env:GITHUB_ENV
+          "BC_TENANT=default" | Add-Content -Path $env:GITHUB_ENV
           "BC_AUTHENTICATION=UserPassword" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,7 +33,9 @@ jobs:
           if (-not $version) {
             throw 'The AL Development Tools installation did not report a version.'
           }
+          $altoolPath = (Get-Command al -ErrorAction Stop).Source
           "ALTOOL_VERSION=$version" | Add-Content -Path $env:GITHUB_ENV
+          "ALTOOL_PATH=$altoolPath" | Add-Content -Path $env:GITHUB_ENV
           Write-Host "Installed AL Development Tools: $version"
 
       - name: Install BcContainerHelper
@@ -86,6 +88,7 @@ jobs:
           "BC_ARTIFACT_URL=$artifactUrl" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_URL=http://$containerName" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_INSTANCE=BC" | Add-Content -Path $env:GITHUB_ENV
+          "BC_SERVER_PORT=7049" | Add-Content -Path $env:GITHUB_ENV
           "BC_AUTHENTICATION=UserPassword" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -87,8 +87,8 @@ jobs:
           "BC_SERVER_URL=http://$containerName" | Add-Content -Path $env:GITHUB_ENV
           "BC_SERVER_INSTANCE=BC" | Add-Content -Path $env:GITHUB_ENV
           "BC_AUTHENTICATION=UserPassword" | Add-Content -Path $env:GITHUB_ENV
-          "BC_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
-          "BC_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV
+          "BC_SERVER_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
+          "BC_SERVER_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV
           Write-Host "Started Business Central container '$containerName' from $artifactUrl."
 
       - name: Verify triage environment

--- a/scripts/Test-AlIssueTriageWorkflow.ps1
+++ b/scripts/Test-AlIssueTriageWorkflow.ps1
@@ -8,6 +8,12 @@ $setup = Get-Content (Join-Path $repositoryRoot '.github\workflows\copilot-setup
 $instructions = Get-Content (
     Join-Path $repositoryRoot '.github\agents\al-issue-triager\AGENTS.md'
 ) -Raw
+$symbolSkill = Get-Content (
+    Join-Path $repositoryRoot '.github\skills\download-al-symbols\SKILL.md'
+) -Raw
+$symbolScript = Get-Content (
+    Join-Path $repositoryRoot '.github\skills\download-al-symbols\Invoke-DownloadAlSymbols.ps1'
+) -Raw
 
 function Assert-Contains([string] $Text, [string] $Expected) {
     if (-not $Text.Contains($Expected)) {
@@ -18,17 +24,17 @@ function Assert-Contains([string] $Text, [string] $Expected) {
 foreach ($text in @(
     'dry_run:',
     'default: true',
+    'Microsoft.Dynamics.BusinessCentral.Development.Tools --prerelease',
     "TRIAGE_DRY_RUN: `${{ github.event_name == 'issues' || inputs.dry_run }}",
     "if: env.TRIAGE_DRY_RUN != 'true'",
     'Upload triage report',
     '$rawOutput.Substring($headingIndex).Trim()',
     "StartsWith('## Automated AL issue triage'",
-    "'al-language' = @{",
-    "command = 'al'",
-    "@('launchmcpserver', '--transport', 'stdio')",
-    '--additional-mcp-config "@$mcpConfigPath"',
+    'ALTOOL_PATH=$altoolPath',
+    'Invoke the download-al-symbols skill',
     'BC_SERVER_USERNAME=admin',
-    'BC_SERVER_PASSWORD=$passwordText'
+    'BC_SERVER_PASSWORD=$passwordText',
+    'BC_SERVER_PORT=7049'
 )) {
     Assert-Contains $workflow $text
 }
@@ -41,14 +47,42 @@ foreach ($text in @(
 }
 
 foreach ($text in @(
-    'AL language MCP server launched by ALTool',
-    '`al_downloadsymbols`',
+    'freshly installed prerelease ALTool',
+    '`download-al-symbols`',
     'never invoke `alc.exe` directly',
     'never call `/dev/packages` manually',
     'Do not disclose sandbox/container availability',
     'The first output characters must'
 )) {
     Assert-Contains $instructions $text
+}
+
+foreach ($text in @(
+    '$env:ALTOOL_PATH',
+    '& $altoolPath --version',
+    "'al_downloadsymbols'",
+    'BC_SERVER_USERNAME',
+    'BC_SERVER_PASSWORD',
+    "contains no symbol packages"
+)) {
+    Assert-Contains $symbolScript $text
+}
+
+foreach ($text in @(
+    'prerelease ALTool',
+    'Do not invoke `alc.exe`',
+    'Do not invoke `alc.exe`, launch or script an MCP server yourself'
+)) {
+    Assert-Contains $symbolSkill $text
+}
+
+foreach ($forbidden in @(
+    '--additional-mcp-config',
+    "'al-language' = @{"
+)) {
+    if ($workflow.Contains($forbidden)) {
+        throw "The triage agent still receives direct MCP configuration: $forbidden"
+    }
 }
 
 if ($instructions.Contains('**Business Central container:**') -or

--- a/scripts/Test-AlIssueTriageWorkflow.ps1
+++ b/scripts/Test-AlIssueTriageWorkflow.ps1
@@ -14,6 +14,12 @@ $symbolSkill = Get-Content (
 $symbolScript = Get-Content (
     Join-Path $repositoryRoot '.github\skills\download-al-symbols\Invoke-DownloadAlSymbols.ps1'
 ) -Raw
+$compileScript = Get-Content (
+    Join-Path $repositoryRoot '.github\skills\compile-al-app\Invoke-CompileAlApp.ps1'
+) -Raw
+$agentRegistration = Get-Content (
+    Join-Path $repositoryRoot '.github\agents\al-issue-triager.agent.md'
+) -Raw
 
 function Assert-Contains([string] $Text, [string] $Expected) {
     if (-not $Text.Contains($Expected)) {
@@ -31,7 +37,8 @@ foreach ($text in @(
     '$rawOutput.Substring($headingIndex).Trim()',
     "StartsWith('## Automated AL issue triage'",
     'ALTOOL_PATH=$altoolPath',
-    'Invoke the download-al-symbols skill',
+    'Invoke verify-prerelease-altool first',
+    'run-al-code-analysis, publish-al-app, run-al-tests, and verify-al-e2e',
     'BC_SERVER_USERNAME=admin',
     'BC_SERVER_PASSWORD=$passwordText',
     'BC_SERVER_PORT=7049'
@@ -67,6 +74,22 @@ foreach ($text in @(
 )) {
     Assert-Contains $symbolScript $text
 }
+if ($symbolScript.Contains('Get-Command al')) {
+    throw 'The symbol wrapper can escape the workflow-installed prerelease ALTool.'
+}
+
+foreach ($text in @(
+    '$env:ALTOOL_PATH',
+    '$env:ALTOOL_VERSION',
+    '"/project:$project"',
+    'Invoke download-al-symbols first',
+    'GetPackageManifest'
+)) {
+    Assert-Contains $compileScript $text
+}
+if ($compileScript.Contains('alc.exe')) {
+    throw 'The compile wrapper invokes the compiler directly.'
+}
 
 foreach ($text in @(
     'prerelease ALTool',
@@ -74,6 +97,24 @@ foreach ($text in @(
     'Do not invoke `alc.exe`, launch or script an MCP server yourself'
 )) {
     Assert-Contains $symbolSkill $text
+}
+
+$requiredSkills = @(
+    'verify-prerelease-altool',
+    'create-al-project',
+    'download-al-symbols',
+    'compile-al-app',
+    'run-al-code-analysis',
+    'publish-al-app',
+    'run-al-tests',
+    'verify-al-e2e'
+)
+foreach ($skill in $requiredSkills) {
+    $skillPath = Join-Path $repositoryRoot ".github\skills\$skill\SKILL.md"
+    if (-not (Test-Path -LiteralPath $skillPath -PathType Leaf)) {
+        throw "Required triage skill is missing: $skill"
+    }
+    Assert-Contains $agentRegistration "- ``$skill``"
 }
 
 foreach ($forbidden in @(

--- a/scripts/Test-AlIssueTriageWorkflow.ps1
+++ b/scripts/Test-AlIssueTriageWorkflow.ps1
@@ -4,6 +4,32 @@ param()
 $ErrorActionPreference = 'Stop'
 $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $workflow = Get-Content (Join-Path $repositoryRoot '.github\workflows\al-issue-triage.yml') -Raw
+
+function Assert-Contains([string] $Text, [string] $Expected) {
+    if (-not $Text.Contains($Expected)) {
+        throw "Expected text was not found: $Expected"
+    }
+}
+
+$workflowScriptsRoot = Join-Path $repositoryRoot 'scripts\al-issue-triage'
+$workflowScripts = @{}
+foreach ($scriptName in @(
+    'Install-TriageTools.ps1',
+    'Start-TriageSandbox.ps1',
+    'Test-AlToolSandboxAccess.ps1',
+    'Get-TriggeringIssue.ps1',
+    'Invoke-AlIssueTriage.ps1',
+    'Test-AlIssueTriageOutput.ps1',
+    'Publish-AlIssueTriageComment.ps1',
+    'Stop-TriageSandbox.ps1'
+)) {
+    $scriptPath = Join-Path $workflowScriptsRoot $scriptName
+    if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+        throw "Required workflow script is missing: $scriptName"
+    }
+    $workflowScripts[$scriptName] = Get-Content -LiteralPath $scriptPath -Raw
+    Assert-Contains $workflow ".\scripts\al-issue-triage\$scriptName"
+}
 $setup = Get-Content (Join-Path $repositoryRoot '.github\workflows\copilot-setup-steps.yml') -Raw
 $instructions = Get-Content (
     Join-Path $repositoryRoot '.github\agents\al-issue-triager\AGENTS.md'
@@ -21,31 +47,37 @@ $agentRegistration = Get-Content (
     Join-Path $repositoryRoot '.github\agents\al-issue-triager.agent.md'
 ) -Raw
 
-function Assert-Contains([string] $Text, [string] $Expected) {
-    if (-not $Text.Contains($Expected)) {
-        throw "Expected text was not found: $Expected"
-    }
-}
-
 foreach ($text in @(
     'dry_run:',
     'default: true',
-    'Microsoft.Dynamics.BusinessCentral.Development.Tools --prerelease',
     "TRIAGE_DRY_RUN: `${{ github.event_name == 'issues' || inputs.dry_run }}",
     "if: env.TRIAGE_DRY_RUN != 'true'",
     'Upload triage report',
-    '$rawOutput.Substring($headingIndex).Trim()',
-    "StartsWith('## Automated AL issue triage'",
-    'ALTOOL_PATH=$altoolPath',
-    'Invoke verify-prerelease-altool first',
-    'run-al-code-analysis, publish-al-app, run-al-tests, and verify-al-e2e',
     'Verify prerelease ALTool sandbox access',
-    'BC_SERVER_USERNAME=admin',
-    'BC_SERVER_PASSWORD=$passwordText',
-    'BC_SERVER_PORT=7049',
-    'BC_TENANT=default'
+    '${{ github.token }}',
+    'if: always()',
+    'actions/upload-artifact@'
 )) {
     Assert-Contains $workflow $text
+}
+
+foreach ($assertion in @(
+    @{ Script = 'Install-TriageTools.ps1'; Text = 'Microsoft.Dynamics.BusinessCentral.Development.Tools --prerelease' },
+    @{ Script = 'Install-TriageTools.ps1'; Text = 'ALTOOL_PATH=$altoolPath' },
+    @{ Script = 'Start-TriageSandbox.ps1'; Text = 'BC_SERVER_USERNAME=admin' },
+    @{ Script = 'Start-TriageSandbox.ps1'; Text = 'BC_SERVER_PASSWORD=$passwordText' },
+    @{ Script = 'Start-TriageSandbox.ps1'; Text = 'BC_SERVER_PORT=7049' },
+    @{ Script = 'Start-TriageSandbox.ps1'; Text = 'BC_TENANT=default' },
+    @{ Script = 'Invoke-AlIssueTriage.ps1'; Text = '$rawOutput.Substring($headingIndex).Trim()' },
+    @{ Script = 'Invoke-AlIssueTriage.ps1'; Text = 'Invoke verify-prerelease-altool first' },
+    @{ Script = 'Invoke-AlIssueTriage.ps1'; Text = 'run-al-code-analysis, publish-al-app, run-al-tests, and verify-al-e2e' },
+    @{ Script = 'Test-AlIssueTriageOutput.ps1'; Text = "StartsWith('## Automated AL issue triage'" }
+)) {
+    Assert-Contains $workflowScripts[$assertion.Script] $assertion.Text
+}
+
+if ([regex]::Matches($workflow, '(?m)^\s+run:\s+\|').Count -ne 0) {
+    throw 'The triage workflow contains inline PowerShell instead of checked-in scripts.'
 }
 
 foreach ($text in @(
@@ -131,7 +163,8 @@ foreach ($forbidden in @(
 }
 
 if ($instructions.Contains('**Business Central container:**') -or
-    $workflow.Contains('**Business Central container:**')) {
+    $workflow.Contains('**Business Central container:**') -or
+    ($workflowScripts.Values -match [regex]::Escape('**Business Central container:**'))) {
     throw 'The public output contract still exposes container availability.'
 }
 
@@ -139,7 +172,8 @@ foreach ($obsolete in @(
     '"BC_USERNAME=admin"',
     '"BC_PASSWORD=$passwordText"'
 )) {
-    if ($workflow.Contains($obsolete) -or $setup.Contains($obsolete)) {
+    if ($workflow.Contains($obsolete) -or $setup.Contains($obsolete) -or
+        ($workflowScripts.Values -match [regex]::Escape($obsolete))) {
         throw "Obsolete ALTool credential variable remains: $obsolete"
     }
 }

--- a/scripts/Test-AlIssueTriageWorkflow.ps1
+++ b/scripts/Test-AlIssueTriageWorkflow.ps1
@@ -1,0 +1,66 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$workflow = Get-Content (Join-Path $repositoryRoot '.github\workflows\al-issue-triage.yml') -Raw
+$setup = Get-Content (Join-Path $repositoryRoot '.github\workflows\copilot-setup-steps.yml') -Raw
+$instructions = Get-Content (
+    Join-Path $repositoryRoot '.github\agents\al-issue-triager\AGENTS.md'
+) -Raw
+
+function Assert-Contains([string] $Text, [string] $Expected) {
+    if (-not $Text.Contains($Expected)) {
+        throw "Expected text was not found: $Expected"
+    }
+}
+
+foreach ($text in @(
+    'dry_run:',
+    'default: true',
+    "TRIAGE_DRY_RUN: `${{ github.event_name == 'issues' || inputs.dry_run }}",
+    "if: env.TRIAGE_DRY_RUN != 'true'",
+    'Upload triage report',
+    '$rawOutput.Substring($headingIndex).Trim()',
+    "StartsWith('## Automated AL issue triage'",
+    "command = 'al'",
+    "@('launchmcpserver', '--transport', 'stdio')",
+    '--additional-mcp-config "@$mcpConfigPath"',
+    'BC_SERVER_USERNAME=admin',
+    'BC_SERVER_PASSWORD=$passwordText'
+)) {
+    Assert-Contains $workflow $text
+}
+
+foreach ($text in @(
+    'BC_SERVER_USERNAME=admin',
+    'BC_SERVER_PASSWORD=$passwordText'
+)) {
+    Assert-Contains $setup $text
+}
+
+foreach ($text in @(
+    '`al_downloadsymbols`',
+    'never invoke `alc.exe` directly',
+    'never call `/dev/packages` manually',
+    'Do not disclose sandbox/container availability',
+    'The first output characters must'
+)) {
+    Assert-Contains $instructions $text
+}
+
+if ($instructions.Contains('**Business Central container:**') -or
+    $workflow.Contains('**Business Central container:**')) {
+    throw 'The public output contract still exposes container availability.'
+}
+
+foreach ($obsolete in @(
+    '"BC_USERNAME=admin"',
+    '"BC_PASSWORD=$passwordText"'
+)) {
+    if ($workflow.Contains($obsolete) -or $setup.Contains($obsolete)) {
+        throw "Obsolete ALTool credential variable remains: $obsolete"
+    }
+}
+
+Write-Host 'AL issue triage workflow contracts passed.'

--- a/scripts/Test-AlIssueTriageWorkflow.ps1
+++ b/scripts/Test-AlIssueTriageWorkflow.ps1
@@ -23,6 +23,7 @@ foreach ($text in @(
     'Upload triage report',
     '$rawOutput.Substring($headingIndex).Trim()',
     "StartsWith('## Automated AL issue triage'",
+    "'al-language' = @{",
     "command = 'al'",
     "@('launchmcpserver', '--transport', 'stdio')",
     '--additional-mcp-config "@$mcpConfigPath"',
@@ -40,6 +41,7 @@ foreach ($text in @(
 }
 
 foreach ($text in @(
+    'AL language MCP server launched by ALTool',
     '`al_downloadsymbols`',
     'never invoke `alc.exe` directly',
     'never call `/dev/packages` manually',

--- a/scripts/Test-AlIssueTriageWorkflow.ps1
+++ b/scripts/Test-AlIssueTriageWorkflow.ps1
@@ -39,16 +39,19 @@ foreach ($text in @(
     'ALTOOL_PATH=$altoolPath',
     'Invoke verify-prerelease-altool first',
     'run-al-code-analysis, publish-al-app, run-al-tests, and verify-al-e2e',
+    'Verify prerelease ALTool sandbox access',
     'BC_SERVER_USERNAME=admin',
     'BC_SERVER_PASSWORD=$passwordText',
-    'BC_SERVER_PORT=7049'
+    'BC_SERVER_PORT=7049',
+    'BC_TENANT=default'
 )) {
     Assert-Contains $workflow $text
 }
 
 foreach ($text in @(
     'BC_SERVER_USERNAME=admin',
-    'BC_SERVER_PASSWORD=$passwordText'
+    'BC_SERVER_PASSWORD=$passwordText',
+    'BC_TENANT=default'
 )) {
     Assert-Contains $setup $text
 }
@@ -70,6 +73,7 @@ foreach ($text in @(
     "'al_downloadsymbols'",
     'BC_SERVER_USERNAME',
     'BC_SERVER_PASSWORD',
+    'BC_TENANT',
     "contains no symbol packages"
 )) {
     Assert-Contains $symbolScript $text

--- a/scripts/al-issue-triage/Get-TriggeringIssue.ps1
+++ b/scripts/al-issue-triage/Get-TriggeringIssue.ps1
@@ -1,0 +1,10 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$issuePath = Join-Path $env:RUNNER_TEMP 'al-triage-issue.json'
+gh api "repos/$env:GITHUB_REPOSITORY/issues/$env:ISSUE_NUMBER" |
+    Set-Content -LiteralPath $issuePath -Encoding utf8
+
+"TRIAGE_ISSUE_NUMBER=$env:ISSUE_NUMBER" | Add-Content -Path $env:GITHUB_ENV
+"TRIAGE_ISSUE_PATH=$issuePath" | Add-Content -Path $env:GITHUB_ENV

--- a/scripts/al-issue-triage/Install-TriageTools.ps1
+++ b/scripts/al-issue-triage/Install-TriageTools.ps1
@@ -1,0 +1,17 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+dotnet tool install --global Microsoft.Dynamics.BusinessCentral.Development.Tools --prerelease
+npm install --global @github/copilot@1.0.79-9
+Install-Module BcContainerHelper -Force -Scope CurrentUser -Repository PSGallery
+
+$alVersion = (& al --version 2>&1 | Out-String).Trim()
+if (-not $alVersion) {
+    throw 'The AL Development Tools installation did not report a version.'
+}
+
+$altoolPath = (Get-Command al -ErrorAction Stop).Source
+"ALTOOL_VERSION=$alVersion" | Add-Content -Path $env:GITHUB_ENV
+"ALTOOL_PATH=$altoolPath" | Add-Content -Path $env:GITHUB_ENV

--- a/scripts/al-issue-triage/Invoke-AlIssueTriage.ps1
+++ b/scripts/al-issue-triage/Invoke-AlIssueTriage.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
+$errorPath = Join-Path $env:RUNNER_TEMP 'al-triage-error.log'
+$prompt = @"
+Triage public microsoft/AL issue #$env:TRIAGE_ISSUE_NUMBER.
+Read the complete issue payload from '$env:TRIAGE_ISSUE_PATH'.
+Follow the al-issue-triager custom agent and its AGENTS.md contract.
+Investigate and reproduce safely using the freshly installed prerelease ALTool and running
+BCInsider sandbox. Invoke verify-prerelease-altool first, then use the smallest applicable
+skill chain from create-al-project, download-al-symbols, compile-al-app,
+run-al-code-analysis, publish-al-app, run-al-tests, and verify-al-e2e. Do not launch or
+script an MCP server, invoke alc.exe directly, or call BC HTTP endpoints manually. Do not
+modify tracked repository files, create a branch, commit, pull request, label, assignment,
+or GitHub comment. Return only the final standardized markdown issue comment; the workflow
+will validate it.
+"@
+
+& copilot `
+    --agent al-issue-triager `
+    --prompt $prompt `
+    --silent `
+    --no-ask-user `
+    --no-remote `
+    --no-remote-export `
+    --disable-builtin-mcps `
+    --allow-all-tools `
+    --allow-all-paths `
+    --allow-all-urls `
+    --secret-env-vars COPILOT_GITHUB_TOKEN `
+    1> $commentPath 2> $errorPath
+if ($LASTEXITCODE -ne 0) {
+    $errorOutput = if (Test-Path -LiteralPath $errorPath) {
+        Get-Content -LiteralPath $errorPath -Raw
+    }
+    throw "Copilot CLI triage failed with exit code $LASTEXITCODE.`n$errorOutput"
+}
+
+$rawOutput = Get-Content -LiteralPath $commentPath -Raw
+$heading = '## Automated AL issue triage'
+$headingIndex = $rawOutput.IndexOf($heading, [StringComparison]::Ordinal)
+if ($headingIndex -lt 0) {
+    throw "Copilot CLI triage output did not contain the required heading.`n$rawOutput"
+}
+
+$normalizedComment = $rawOutput.Substring($headingIndex).Trim()
+Set-Content -LiteralPath $commentPath -Value $normalizedComment -Encoding utf8

--- a/scripts/al-issue-triage/Publish-AlIssueTriageComment.ps1
+++ b/scripts/al-issue-triage/Publish-AlIssueTriageComment.ps1
@@ -1,0 +1,18 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
+$existingComment = gh api `
+    "repos/$env:GITHUB_REPOSITORY/issues/$env:TRIAGE_ISSUE_NUMBER/comments" `
+    --paginate `
+    --jq '.[] | select(.body | startswith("## Automated AL issue triage")) | .id' |
+    Select-Object -First 1
+if ($existingComment) {
+    Write-Host "Issue #$env:TRIAGE_ISSUE_NUMBER already has an automated triage comment."
+    exit 0
+}
+
+gh issue comment $env:TRIAGE_ISSUE_NUMBER `
+    --repo $env:GITHUB_REPOSITORY `
+    --body-file $commentPath

--- a/scripts/al-issue-triage/Start-TriageSandbox.ps1
+++ b/scripts/al-issue-triage/Start-TriageSandbox.ps1
@@ -1,0 +1,44 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Import-Module BcContainerHelper -Force
+
+$artifactUrl = Get-BcArtifactUrl -Type Sandbox -Country w1 -Select Latest `
+    -StorageAccount bcinsider -Accept_InsiderEula
+if (-not $artifactUrl -or [string]$artifactUrl -notmatch '(?i)bcinsider') {
+    throw "Could not resolve a BCInsider Platform master sandbox artifact: '$artifactUrl'."
+}
+
+$containerName = 'al-public-triage'
+$passwordText = [guid]::NewGuid().ToString('N') + 'aA1!'
+Write-Host "::add-mask::$passwordText"
+$credential = [pscredential]::new(
+    'admin',
+    (ConvertTo-SecureString $passwordText -AsPlainText -Force)
+)
+
+New-BcContainer `
+    -Accept_Eula `
+    -Accept_InsiderEula `
+    -ContainerName $containerName `
+    -ArtifactUrl $artifactUrl `
+    -Auth UserPassword `
+    -Credential $credential `
+    -UpdateHosts `
+    -Shortcuts None `
+    -IncludeAL
+
+if (-not (Get-BcContainerId -ContainerName $containerName)) {
+    throw "Business Central container '$containerName' was not created."
+}
+
+"BC_CONTAINER_NAME=$containerName" | Add-Content -Path $env:GITHUB_ENV
+"BC_ARTIFACT_URL=$artifactUrl" | Add-Content -Path $env:GITHUB_ENV
+"BC_SERVER_URL=http://$containerName" | Add-Content -Path $env:GITHUB_ENV
+"BC_SERVER_INSTANCE=BC" | Add-Content -Path $env:GITHUB_ENV
+"BC_SERVER_PORT=7049" | Add-Content -Path $env:GITHUB_ENV
+"BC_TENANT=default" | Add-Content -Path $env:GITHUB_ENV
+"BC_AUTHENTICATION=UserPassword" | Add-Content -Path $env:GITHUB_ENV
+"BC_SERVER_USERNAME=admin" | Add-Content -Path $env:GITHUB_ENV
+"BC_SERVER_PASSWORD=$passwordText" | Add-Content -Path $env:GITHUB_ENV

--- a/scripts/al-issue-triage/Stop-TriageSandbox.ps1
+++ b/scripts/al-issue-triage/Stop-TriageSandbox.ps1
@@ -1,0 +1,10 @@
+[CmdletBinding()]
+param()
+
+if (Get-Module BcContainerHelper -ListAvailable) {
+    Import-Module BcContainerHelper -Force
+    if ($env:BC_CONTAINER_NAME -and
+        (Get-BcContainerId -ContainerName $env:BC_CONTAINER_NAME)) {
+        Remove-BcContainer -ContainerName $env:BC_CONTAINER_NAME
+    }
+}

--- a/scripts/al-issue-triage/Test-AlIssueTriageOutput.ps1
+++ b/scripts/al-issue-triage/Test-AlIssueTriageOutput.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$commentPath = Join-Path $env:RUNNER_TEMP 'al-triage-comment.md'
+$comment = Get-Content -LiteralPath $commentPath -Raw
+
+$requiredText = @(
+    '## Automated AL issue triage',
+    '**Classification:**',
+    '**Summary:**',
+    '### Environment',
+    '**AL Development Tools:**',
+    '**Business Central artifact:**',
+    '### Attempts and results',
+    '| Report completeness |',
+    '| Duplicate search |',
+    '| Repository investigation |',
+    '| ALTool reproduction |',
+    '| BC runtime reproduction |',
+    '### Assessment',
+    '### Recommended next step'
+)
+foreach ($text in $requiredText) {
+    if (-not $comment.Contains($text)) {
+        throw "Triage output is missing required text '$text'."
+    }
+}
+
+if (-not $comment.StartsWith('## Automated AL issue triage', [StringComparison]::Ordinal)) {
+    throw 'Triage output contains text before the required heading.'
+}
+if ($comment.Length -gt 12000) {
+    throw "Triage output is too long ($($comment.Length) characters)."
+}
+if ($env:BC_SERVER_PASSWORD -and $comment.Contains($env:BC_SERVER_PASSWORD)) {
+    throw 'Triage output contains the ephemeral sandbox password.'
+}
+if (git status --porcelain) {
+    throw 'The triage agent modified tracked or untracked repository files.'
+}
+
+"## Triage result for issue #$env:TRIAGE_ISSUE_NUMBER" |
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY
+if ($env:TRIAGE_DRY_RUN -eq 'true') {
+    '> Dry run: validated and archived without posting to GitHub.' |
+        Add-Content -Path $env:GITHUB_STEP_SUMMARY
+}
+$comment | Add-Content -Path $env:GITHUB_STEP_SUMMARY

--- a/scripts/al-issue-triage/Test-AlToolSandboxAccess.ps1
+++ b/scripts/al-issue-triage/Test-AlToolSandboxAccess.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$projectPath = Join-Path $env:RUNNER_TEMP 'altool-sandbox-preflight'
+New-Item -ItemType Directory -Path $projectPath -Force | Out-Null
+
+$artifactVersion = [regex]::Match(
+    $env:BC_ARTIFACT_URL,
+    '/(?<version>\d+\.\d+\.\d+\.\d+)/'
+).Groups['version'].Value
+if (-not $artifactVersion) {
+    throw "Could not determine the BC artifact version from '$env:BC_ARTIFACT_URL'."
+}
+
+$versionParts = $artifactVersion.Split('.')
+$applicationVersion = "$($versionParts[0]).$($versionParts[1]).0.0"
+[ordered]@{
+    id = [guid]::NewGuid().ToString()
+    name = 'Public AL Triage Preflight'
+    publisher = 'Microsoft'
+    version = '1.0.0.0'
+    platform = $applicationVersion
+    application = $applicationVersion
+    target = 'OnPrem'
+    idRanges = @([ordered]@{ from = 50100; to = 50100 })
+} | ConvertTo-Json -Depth 5 |
+    Set-Content -LiteralPath (Join-Path $projectPath 'app.json') -Encoding utf8
+
+try {
+    & .\.github\skills\download-al-symbols\Invoke-DownloadAlSymbols.ps1 `
+        -ProjectPath $projectPath
+}
+finally {
+    Remove-Item -LiteralPath $projectPath -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

- adds a dry-run mode that validates and archives triage reports without posting issue comments, enabled by default for manual runs and enforced for newly opened issues;
- gives the agent a deterministic `download-al-symbols` skill using the freshly installed public prerelease ALTool, matching the internal workflow;
- fixes the sandbox credential variable names to `BC_SERVER_USERNAME` / `BC_SERVER_PASSWORD`, which ALTool actually reads;
- prohibits agent-driven MCP setup, direct `alc.exe`, and manual `/dev/packages` calls;
- strips progress narration before the standardized triage heading and removes container availability from public comments.

## Issue #8313 diagnosis

The workflow exported `BC_USERNAME` / `BC_PASSWORD`, but ALTool resolves non-interactive UserPassword credentials only from `BC_SERVER_USERNAME` / `BC_SERVER_PASSWORD`. The agent also bypassed ALTool by invoking `alc.exe` directly, then treated a manual `/dev/packages` 401 as evidence that symbols were unavailable.

The replacement workflow installs the latest prerelease `Microsoft.Dynamics.BusinessCentral.Development.Tools`, records that exact `al.exe` as `ALTOOL_PATH`, and requires the deterministic symbol skill before compilation. The skill owns ALTool's internal symbol-download protocol so the agent only invokes the command-line workflow.

## Verification

- exact prerelease package `18.0.40.43394-beta` inspected in an isolated tool path;
- workflow contract script passes;
- modified workflows parse as YAML;
- symbol wrapper parses as PowerShell;
- preamble normalization removes the narration seen on issue #8313.